### PR TITLE
Support actions with arguments

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/abhinav/tmux-fastcopy/internal/log"
+	shellwords "github.com/mattn/go-shellwords"
+)
+
+const _placeholderArg = "{}"
+
+type actionFactory struct {
+	Log *log.Logger
+}
+
+// New builds a command handler from the provided string.
+//
+// The string is a multi-word shell command. It should use "{}" as an argument
+// to reference the selected text. If no "{}" is present, the selection will be
+// sent to the command over stdin.
+func (f *actionFactory) New(action string) (action, error) {
+	args, err := shellwords.Parse(action)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(args) == 0 {
+		return nil, errors.New("empty action")
+	}
+
+	cmd, args := args[0], args[1:]
+	for i, arg := range args {
+		if arg == _placeholderArg {
+			return &argAction{
+				Cmd:        cmd,
+				BeforeArgs: args[:i],
+				AfterArgs:  args[i+1:],
+				Log:        f.Log,
+			}, nil
+		}
+	}
+
+	// No "{}" use stdin.
+	return &stdinAction{
+		Cmd:  cmd,
+		Args: args,
+		Log:  f.Log,
+	}, nil
+}
+
+// action specifies how to handle the user's selection.
+type action interface{ Run(selection string) error }
+
+type stdinAction struct {
+	Cmd  string
+	Args []string
+	Log  *log.Logger
+}
+
+func (h *stdinAction) Run(text string) error {
+	logw := &log.Writer{
+		Log: h.Log.WithName(h.Cmd),
+	}
+	defer logw.Close()
+
+	cmd := exec.Command(h.Cmd, h.Args...)
+	cmd.Stdin = strings.NewReader(text)
+	cmd.Stdout = logw
+	cmd.Stderr = logw
+	return cmd.Run()
+}
+
+type argAction struct {
+	Cmd                   string
+	BeforeArgs, AfterArgs []string
+	Log                   *log.Logger
+}
+
+func (h *argAction) Run(text string) error {
+	logw := &log.Writer{
+		Log: h.Log.WithName(h.Cmd),
+	}
+	defer logw.Close()
+
+	args := make([]string, 0, len(h.BeforeArgs)+len(h.AfterArgs)+1)
+	args = append(args, h.BeforeArgs...)
+	args = append(args, text)
+	args = append(args, h.AfterArgs...)
+
+	cmd := exec.Command(h.Cmd, args...)
+	cmd.Stdout = logw
+	cmd.Stderr = logw
+	return cmd.Run()
+}

--- a/action_test.go
+++ b/action_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/abhinav/tmux-fastcopy/internal/log"
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestNewCommandAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give string
+
+		wantArg   *argAction
+		wantStdin *stdinAction
+		wantErr   string
+	}{
+		{
+			desc:    "empty",
+			give:    "",
+			wantErr: `empty action`,
+		},
+		{
+			desc:    "parse error",
+			give:    `foo "`,
+			wantErr: `invalid command line string`,
+		},
+		{
+			desc: "stdin",
+			give: "pbcopy",
+			wantStdin: &stdinAction{
+				Cmd:  "pbcopy",
+				Args: []string{},
+			},
+		},
+		{
+			desc: "argument",
+			give: "tmux set-buffer -- {}",
+			wantArg: &argAction{
+				Cmd:        "tmux",
+				BeforeArgs: []string{"set-buffer", "--"},
+				AfterArgs:  []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := new(actionFactory).New(tt.give)
+			switch {
+			case len(tt.wantErr) > 0:
+				td.CmpError(t, err)
+				td.CmpContains(t, err.Error(), tt.wantErr)
+
+			case tt.wantArg != nil:
+				td.CmpNoError(t, err)
+				td.Cmp(t, got, tt.wantArg)
+
+			case tt.wantStdin != nil:
+				td.CmpNoError(t, err)
+				td.Cmp(t, got, tt.wantStdin)
+
+			default:
+				t.Fatal("invalid test case")
+			}
+		})
+	}
+}
+
+func TestStdinAction(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+
+	action := stdinAction{
+		Cmd: "cat",
+		Log: log.New(&buff),
+	}
+	td.CmpNoError(t, action.Run("foo"))
+	td.Cmp(t, buff.String(), "[cat] foo\n")
+}
+
+func TestArgAction(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	action := argAction{
+		Cmd:        "echo",
+		BeforeArgs: []string{"1", "2"},
+		AfterArgs:  []string{"3", "4"},
+		Log:        log.New(&buff),
+	}
+	td.CmpNoError(t, action.Run("foo"))
+	td.Cmp(t, buff.String(), "[echo] 1 2 foo 3 4\n")
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.13
+	github.com/mattn/go-shellwords v1.0.12
 	github.com/maxatome/go-testdeep v1.9.2
 	github.com/rivo/uniseg v0.2.0
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/maxatome/go-testdeep v1.9.2 h1:5D7u/JkeG0A/HDTbZ/CFFmpYZPeWN+uGQ1IbsEHYlCo=
 github.com/maxatome/go-testdeep v1.9.2/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -29,9 +29,6 @@ type Driver interface {
 	// SendSignal runs the tmux wait-for command, activating anyone waiting
 	// for this signal.
 	SendSignal(string) error
-
-	// SetBuffer runs the tmux set-buffer command.
-	SetBuffer(SetBufferRequest) error
 }
 
 // NewSessionRequest specifies the parameter for a new-session command.
@@ -136,18 +133,5 @@ func (r ResizeWindowRequest) String() string {
 	b.Put("window", r.Window)
 	b.Put("width", r.Width)
 	b.Put("height", r.Height)
-	return b.String()
-}
-
-// SetBufferRequest specifies the parameters for a set-buffer command.
-type SetBufferRequest struct {
-	Client string
-	Data   string
-}
-
-func (r SetBufferRequest) String() string {
-	var b stringobj.Builder
-	b.Put("client", r.Client)
-	b.Put("data", r.Data)
 	return b.String()
 }

--- a/internal/tmux/inspect.go
+++ b/internal/tmux/inspect.go
@@ -20,25 +20,20 @@ const (
 
 // PaneInfo reports information about a tmux pane.
 type PaneInfo struct {
-	ID               string
-	WindowID         string
-	ClientName       string
-	Width, Height    int
-	Mode             PaneMode
-	CursorX, CursorY int
-	ScrollPosition   int
+	ID             string
+	WindowID       string
+	Width, Height  int
+	Mode           PaneMode
+	ScrollPosition int
 }
 
 func (i *PaneInfo) String() string {
 	var b stringobj.Builder
 	b.Put("id", i.ID)
 	b.Put("windowID", i.WindowID)
-	b.Put("clientName", i.ClientName)
 	b.Put("width", i.Width)
 	b.Put("width", i.Height)
 	b.Put("mode", i.Mode)
-	b.Put("cursorX", i.CursorX)
-	b.Put("cursorY", i.CursorY)
 	b.Put("scrollPosition", i.ScrollPosition)
 	return b.String()
 }
@@ -57,23 +52,12 @@ var (
 		Op:  tmuxfmt.Equals,
 		RHS: tmuxfmt.String("copy-mode"),
 	}
-	_paneCursorX = tmuxfmt.Ternary{
-		Cond: _paneInCopyMode,
-		Then: tmuxfmt.Var("copy_cursor_x"),
-		Else: tmuxfmt.Var("cursor_x"),
-	}
-	_paneCursorY = tmuxfmt.Ternary{
-		Cond: _paneInCopyMode,
-		Then: tmuxfmt.Var("copy_cursor_y"),
-		Else: tmuxfmt.Var("cursor_y"),
-	}
 	_paneScrollPosition = tmuxfmt.Ternary{
 		Cond: _paneInCopyMode,
 		Then: tmuxfmt.Var("scroll_position"),
 		Else: tmuxfmt.Int(0),
 	}
-	_windowID   = tmuxfmt.Var("window_id")
-	_clientName = tmuxfmt.Var("client_name")
+	_windowID = tmuxfmt.Var("window_id")
 )
 
 // InspectPane inspects a tmux pane and reports information about it. The
@@ -86,12 +70,9 @@ func InspectPane(driver Driver, identifier string) (*PaneInfo, error) {
 	)
 	fc.StringVar(&info.ID, _paneID)
 	fc.StringVar(&info.WindowID, _windowID)
-	fc.StringVar(&info.ClientName, _clientName)
 	fc.IntVar(&info.Width, _paneWidth)
 	fc.IntVar(&info.Height, _paneHeight)
 	fc.StringVar((*string)(&info.Mode), _paneMode)
-	fc.IntVar(&info.CursorX, _paneCursorX)
-	fc.IntVar(&info.CursorY, _paneCursorY)
 	fc.IntVar(&info.ScrollPosition, _paneScrollPosition)
 
 	msg, parse := fc.Prepare()

--- a/internal/tmux/shell.go
+++ b/internal/tmux/shell.go
@@ -189,19 +189,3 @@ func (s *ShellDriver) SendSignal(sig string) error {
 	s.Log.Debugf("wait-for -S: %v", sig)
 	return cmd.Run()
 }
-
-func (s *ShellDriver) SetBuffer(req SetBufferRequest) error {
-	s.init()
-
-	args := []string{"set-buffer"}
-	if c := req.Client; len(c) > 0 {
-		args = append(args, "-t", c)
-	}
-	args = append(args, req.Data)
-
-	cmd := s.cmd(args...)
-	defer s.errorWriter(&cmd.Stdout, &cmd.Stderr)()
-
-	s.Log.Debugf("set buffer: %v", req)
-	return cmd.Run()
-}

--- a/internal/tmux/tmuxtest/mocks.go
+++ b/internal/tmux/tmuxtest/mocks.go
@@ -107,20 +107,6 @@ func (mr *MockDriverMockRecorder) SendSignal(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSignal", reflect.TypeOf((*MockDriver)(nil).SendSignal), arg0)
 }
 
-// SetBuffer mocks base method.
-func (m *MockDriver) SetBuffer(arg0 tmux.SetBufferRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetBuffer", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetBuffer indicates an expected call of SetBuffer.
-func (mr *MockDriverMockRecorder) SetBuffer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBuffer", reflect.TypeOf((*MockDriver)(nil).SetBuffer), arg0)
-}
-
 // SwapPane mocks base method.
 func (m *MockDriver) SwapPane(arg0 tmux.SwapPaneRequest) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Change `-action` to accept commands where arguments are specified. The
special argument `{}` refers to the selected text. If no `{}` is
present, the selected text is sent over stdin.

This allows dropping `tmux set-buffer` special-casing completely in
favor of a general `tmux set-buffer` command default.
