### PR TITLE
Support alphabet customization

### DIFF
--- a/action.go
+++ b/action.go
@@ -9,7 +9,10 @@ import (
 	shellwords "github.com/mattn/go-shellwords"
 )
 
-const _placeholderArg = "{}"
+const (
+	_placeholderArg = "{}"
+	_defaultAction  = "tmux set-buffer -- {}"
+)
 
 type actionFactory struct {
 	Log *log.Logger

--- a/alphabet.go
+++ b/alphabet.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+const _defaultAlphabet = "abcdefghijklmnopqrstuvwxyz"
+
+func validateAlphabet(alpha string) error {
+	if len(alpha) < 2 {
+		return errors.New("alphabet must have at least two items")
+	}
+
+	seen := make(map[rune]struct{}, len(alpha))
+	dupes := make(map[rune]struct{})
+	for _, r := range alpha {
+		if _, ok := seen[r]; ok {
+			dupes[r] = struct{}{}
+		}
+		seen[r] = struct{}{}
+	}
+
+	if len(dupes) == 0 {
+		return nil
+	}
+
+	dlist := make([]rune, 0, len(dupes))
+	for r := range dupes {
+		dlist = append(dlist, r)
+	}
+	sort.Slice(dlist, func(i, j int) bool {
+		return dlist[i] < dlist[j]
+	})
+
+	return fmt.Errorf("alphabet has duplicates: %q", dlist)
+}

--- a/alphabet_test.go
+++ b/alphabet_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestValidateAlphabet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		give    string
+		wantErr string
+	}{
+		{
+			desc:    "empty",
+			wantErr: "must have at least two items",
+		},
+		{
+			desc:    "single",
+			give:    "a",
+			wantErr: "must have at least two items",
+		},
+		{
+			desc: "good",
+			give: "0123456789",
+		},
+		{
+			desc:    "dupes",
+			give:    "asdffghhjjkl",
+			wantErr: "alphabet has duplicates: ['f' 'h' 'j']",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAlphabet(tt.give)
+			if len(tt.wantErr) == 0 {
+				td.CmpNoError(t, err)
+				return
+			}
+
+			td.CmpError(t, err)
+			td.CmpContains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/app.go
+++ b/app.go
@@ -22,8 +22,6 @@ var _regex = []*regexp.Regexp{
 	regexp.MustCompile(`[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}`),
 }
 
-var _alphabet = []rune("abcdefghijklmnopqrstuvwxyz")
-
 // app implements the main fastcopy application logic. It assumes that it's
 // running inside a tmux window that it has full control over. (wrapper takes
 // care of ensuring that.)
@@ -89,9 +87,10 @@ func (app *app) Run(cfg *config) error {
 	defer screen.Fini()
 
 	ctrl := ctrl{
-		Screen: screen,
-		Log:    app.Log,
-		Text:   string(bs),
+		Screen:   screen,
+		Log:      app.Log,
+		Text:     string(bs),
+		Alphabet: []rune(cfg.Alphabet),
 	}
 	ctrl.Init()
 
@@ -119,9 +118,10 @@ func (app *app) Run(cfg *config) error {
 }
 
 type ctrl struct {
-	Screen tcell.Screen
-	Log    *log.Logger
-	Text   string
+	Screen   tcell.Screen
+	Log      *log.Logger
+	Alphabet []rune
+	Text     string
 
 	w   *Widget
 	ui  *ui.App
@@ -146,7 +146,7 @@ func (c *ctrl) Init() {
 		Text:         c.Text,
 		Matches:      ms,
 		Handler:      c,
-		HintAlphabet: _alphabet,
+		HintAlphabet: c.Alphabet,
 		Style: Style{
 			Normal:         base,
 			Match:          base.Foreground(tcell.ColorGreen),

--- a/config.go
+++ b/config.go
@@ -7,20 +7,24 @@ import (
 )
 
 type config struct {
-	Pane    string
-	Verbose bool
+	Pane     string
+	Action   string
+	Alphabet string
+
 	LogFile string
-	Action  string
+	Verbose bool
 }
 
 func newConfig(flag *flag.FlagSet) *config {
 	var c config
 
 	// No help here because we put it all in _usage.
+
 	flag.StringVar(&c.Pane, "pane", "", "")
 	flag.StringVar(&c.Action, "action", "", "")
-	flag.BoolVar(&c.Verbose, "verbose", false, "")
+	flag.StringVar(&c.Alphabet, "alphabet", "", "")
 	flag.StringVar(&c.LogFile, "log", "", "")
+	flag.BoolVar(&c.Verbose, "verbose", false, "")
 
 	return &c
 }
@@ -32,14 +36,17 @@ func (c *config) Args() []string {
 	if len(c.Pane) > 0 {
 		args = append(args, "-pane", c.Pane)
 	}
+	if len(c.Action) > 0 {
+		args = append(args, "-action", c.Action)
+	}
+	if len(c.Alphabet) > 0 {
+		args = append(args, "-alphabet", c.Alphabet)
+	}
 	if c.Verbose {
 		args = append(args, "-verbose")
 	}
 	if len(c.LogFile) > 0 {
 		args = append(args, "-log", c.LogFile)
-	}
-	if len(c.Action) > 0 {
-		args = append(args, "-action", c.Action)
 	}
 	return args
 }

--- a/main.go
+++ b/main.go
@@ -51,18 +51,20 @@ The following flags are available:
 	-action COMMAND
 		command and arguments that handle the selection.
 		The first '{}' in the argument list is the selected text.
-			-action 'tmux set-buffer -- {}'
+			-action 'tmux set-buffer -- {}'  # default
 		If there is no '{}', the selected text is sent over stdin.
 			-action pbcopy
 		Uses 'tmux set-buffer' by default.
+	-alphabet STRING
+		characters used for hints in-order.
+			-alphabet "asdfghjkl;"  # qwerty home row
+		Uses the English alphabet by default.
 	-log FILE
 		file to write logs to.
 		Uses stderr by default.
 	-verbose
 		log more output.
 `
-
-const _defaultAction = "tmux set-buffer -- {}"
 
 func (cmd *mainCmd) Run(args []string) error {
 	flag := flag.NewFlagSet("tmux-fastcopy", flag.ContinueOnError)
@@ -84,6 +86,14 @@ func (cmd *mainCmd) Run(args []string) error {
 
 	if len(cfg.Action) == 0 {
 		cfg.Action = _defaultAction
+	}
+
+	if alpha := cfg.Alphabet; len(alpha) > 0 {
+		if err := validateAlphabet(alpha); err != nil {
+			return err
+		}
+	} else {
+		cfg.Alphabet = _defaultAlphabet
 	}
 
 	logW, closeLog, err := cfg.BuildLogWriter(cmd.Stderr)


### PR DESCRIPTION
Add an `-alphabet` flag that allows specifying the letters that comprise
a hint. Defaults to the english alphabet but supports anything as long
as it breaks down to at least two runes.
