### PR TITLE
test/config/quick: Don't test with invalid alphabets

### DIFF
--- a/alphabet.go
+++ b/alphabet.go
@@ -18,13 +18,18 @@ func (al *alphabet) String() string {
 }
 
 func (al *alphabet) Set(alpha string) error {
-	if len(alpha) < 2 {
+	*al = alphabet(alpha)
+	return al.Validate()
+}
+
+func (al alphabet) Validate() error {
+	if len(al) < 2 {
 		return errors.New("alphabet must have at least two items")
 	}
 
-	seen := make(map[rune]struct{}, len(alpha))
+	seen := make(map[rune]struct{}, len(al))
 	dupes := make(map[rune]struct{})
-	for _, r := range alpha {
+	for _, r := range al {
 		if _, ok := seen[r]; ok {
 			dupes[r] = struct{}{}
 		}
@@ -32,9 +37,7 @@ func (al *alphabet) Set(alpha string) error {
 	}
 
 	if len(dupes) == 0 {
-		// success!
-		*al = alphabet(alpha)
-		return nil
+		return nil // success
 	}
 
 	dlist := make([]rune, 0, len(dupes))

--- a/config_test.go
+++ b/config_test.go
@@ -156,6 +156,11 @@ func TestConfigFlagsQuickCheck(t *testing.T) {
 
 	random := rand.New(rand.NewSource(seed))
 	quick.Check(func(give config) bool {
+		// Skip invalid alphabets.
+		if give.Alphabet.Validate() != nil {
+			return true
+		}
+
 		flag := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
 		var got config
 		got.RegisterFlags(flag)


### PR DESCRIPTION
The test would fail sometimes when it generated alphabets with duplicate
items. Make sure we only test with valid alphabets.

This reduces the efficacy of this test somewhat, but until fuzzing is
available, this seems the most reasonable way.
