### PR TITLE
Download binary from Github if Go is unavailable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,9 @@
 project_name: tmux-fastcopy
 before:
   hooks:
-    - make lint
+    # Verify that the version number in the install.sh matches the planned
+    # version.
+    - ./install.sh -c {{.Version}}
 builds:
   - env:
       - CGO_ENABLED=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Download pre-built binary from GitHub if Go isn't available.
+
 ## 0.1.0 - 2021-08-14
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Refresh your tmux server if it's already running.
 
 ### Binary installation
 
-Alternatively, instead of instaling tmux-fastcopy as a tmux plugin, you can
+Alternatively, instead of installing tmux-fastcopy as a tmux plugin, you can
 install it as an independent binary.
 
 1. Download a pre-built binary from the [releases page][] and place it on your

--- a/fastcopy.tmux
+++ b/fastcopy.tmux
@@ -7,20 +7,14 @@ fi
 
 FASTCOPY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FASTCOPY_EXE="$FASTCOPY_ROOT/bin/tmux-fastcopy"
-if [[ ! -x "$FASTCOPY_EXE" ]]; then
-	FASTCOPY_EXE=$(command -v tmux-fastcopy)
-fi
-
-if [[ -n "$FASTCOPY_EXE" ]]; then
-	tmux bind-key "$FASTCOPY_KEY" run-shell -b "$FASTCOPY_EXE"
-else
-	if command -v go >/dev/null; then
-		tmux display-message 'Building tmux-fastcopy...'
-		tmux split-window -c "$FASTCOPY_ROOT" \
-			-e "GOBIN=$FASTCOPY_ROOT/bin" \
-			"go install github.com/abhinav/tmux-fastcopy"
+if [ ! -x "$FASTCOPY_EXE" ]; then
+	if command -v tmux-fastcopy >/dev/null; then
+		# Fall back to a globally installed version if available.
+		FASTCOPY_EXE=tmux-fastcopy
 	else
-		tmux display-message -d 0 \
-			"tmux-fastcopy not installed. Plese check the README."
+		tmux display-message 'Installing tmux-fastcopy locally...'
+		tmux split-window -c "$FASTCOPY_ROOT" "$FASTCOPY_ROOT/install.sh"
 	fi
 fi
+
+tmux bind-key "$FASTCOPY_KEY" run-shell -b "$FASTCOPY_EXE"

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,30 @@ IFS=$'\n\t'
 
 # Places a copy of tmux-fastcopy at bin/tmux-fastcopy.
 
+# Invoke with "-c $VERSION" to check if this would install "$VERSION".
+
 IMPORTPATH=github.com/abhinav/tmux-fastcopy
 NAME=tmux-fastcopy
 VERSION=0.1.0
+
+while getopts 'c:' opt; do
+	case "$opt" in
+		c)
+			if [[ "$VERSION" == "$OPTARG" ]]; then
+				echo >&2 "Versions match!"
+				exit 0
+			fi
+			echo >&2 "Version mismatch:"
+			echo >&2 "  want: $VERSION"
+			echo >&2 "   got: $OPTARG"
+			exit 1
+			;;
+		'?')
+			exit 1
+	esac
+done
+shift "$((OPTIND-1))"
+
 OS=$(uname -s)
 ARCH=$(uname -m)
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Places a copy of tmux-fastcopy at bin/tmux-fastcopy.
+
+IMPORTPATH=github.com/abhinav/tmux-fastcopy
+NAME=tmux-fastcopy
+VERSION=0.1.0
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BINDIR="$PROJECT_ROOT/bin"
+EXE="$BINDIR/$NAME"
+
+DOWNLOADS_URL="https://$IMPORTPATH/releases/download"
+
+# Build from source if go is available.
+# No arguments.
+try_build() {
+	command -v go >/dev/null &&
+		echo >&2 "Building from source..." &&
+		(cd "$PROJECT_ROOT" && go build -o "$EXE")
+}
+
+# Downoad with curl. Takes the URL as an argument.
+try_curl() {
+	command -v curl >/dev/null &&
+		echo >&2 "Downloading with curl..." &&
+		curl -L -o >(tar -xvz -C "$BINDIR" "$NAME") "$1"
+}
+
+# Download with wget. Takes the URL as an argument.
+try_wget() {
+	command -v wget >/dev/null &&
+		echo >&2 "Downloading with wget..." &&
+		wget -O >(tar -xvz -C "$BINDIR" "$NAME") "$1"
+}
+
+# Downloads a pre-built binary.
+try_download() {
+	tarball="${NAME}_${VERSION}_${OS}_${ARCH}.tar.gz"
+	url="$DOWNLOADS_URL/v${VERSION}/$tarball"
+
+	mkdir -p "$BINDIR"
+	if (try_curl "$url") || (try_wget "$url"); then
+		chmod +x "$EXE"
+	fi
+}
+
+if ! (try_build || try_download); then
+	echo >&2 "Unable to build or download $NAME."
+	echo >&2 "This means,"
+	echo >&2 "  1. You do not have Go installed; and"
+	echo >&2 "  2. You are using an OS, architecutre, or version for which we"
+	echo >&2 "     do not distribute pre-built binaries."
+	echo >&2 "Please resolve one of these issues and try again."
+	echo >&2
+	echo >&2 "Press any key to continue:"
+	read -rk1
+	exit 1
+fi


### PR DESCRIPTION
If a Go compiler is not available, or we fail to build from source for
any reason, attempt to download pre-built binaries from GitHub--if
available.

Add a release check to verify that the version in the install.sh matches
the version being released.
