### PR TITLE
Support custom regular expressions

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,14 +1,85 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/abhinav/tmux-fastcopy/internal/tmux/tmuxopt"
 )
 
+var _defaultRegexes = map[string]string{
+	"ipv4":     `\b\d{1,3}(?:\.\d{1,3}){3}\b`,
+	"gitsha":   `\b[0-9a-f]{7,40}\b`,
+	"hexaddr":  `\b(?i)0x[0-9a-f]{2,}\b`,
+	"hexcolor": `(?i)#(?:[0-9a-f]{3}|[0-9a-f]{6})\b`,
+	"int":      `(?:-?|\b)\d{4,}\b`,
+	"path":     `(?:[\w\-\.]+|~)?(?:/[\w\-\.]+){2,}\b`,
+	"uuid":     `\b(?i)[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b`,
+	"isodate":  `\d{4}-\d{2}-\d{2}`,
+}
+
 var _defaultConfig = config{
 	Action:   _defaultAction,
 	Alphabet: _defaultAlphabet,
+	Regexes:  _defaultRegexes,
+}
+
+// regexes is a map from regex name to body. If body is empty, this regex
+// should be skipped.
+type regexes map[string]string
+
+func (m *regexes) Put(k, v string) error {
+	if len(k) == 0 {
+		return errors.New("regex must have a name")
+	}
+
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	(*m)[k] = v
+	return nil
+}
+
+func (m regexes) Flags() (args []string) {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		args = append(args, "-regex", name+":"+m[name])
+	}
+
+	return args
+}
+
+func (m regexes) String() string {
+	return fmt.Sprint(m.Flags())
+}
+
+func (m *regexes) Set(v string) error {
+	idx := strings.IndexByte(v, ':')
+	if idx < 0 {
+		return errors.New("regex flags must be in the form NAME:REGEX")
+	}
+
+	if err := m.Put(v[:idx], v[idx+1:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *regexes) FillFrom(o regexes) {
+	for k, v := range o {
+		if _, ok := (*m)[k]; !ok {
+			m.Put(k, v)
+		}
+	}
 }
 
 type config struct {
@@ -16,6 +87,7 @@ type config struct {
 	Action   string
 	Alphabet alphabet
 	Verbose  bool
+	Regexes  regexes
 }
 
 func (c *config) RegisterFlags(flag *flag.FlagSet) {
@@ -23,12 +95,14 @@ func (c *config) RegisterFlags(flag *flag.FlagSet) {
 	flag.StringVar(&c.Pane, "pane", "", "")
 	flag.StringVar(&c.Action, "action", "", "")
 	flag.Var(&c.Alphabet, "alphabet", "")
+	flag.Var(&c.Regexes, "regex", "")
 	flag.BoolVar(&c.Verbose, "verbose", false, "")
 }
 
 func (c *config) RegisterOptions(load *tmuxopt.Loader) {
 	load.StringVar(&c.Action, "@fastcopy-action")
 	load.Var(&c.Alphabet, "@fastcopy-alphabet")
+	load.MapVar(&c.Regexes, "@fastcopy-regex-")
 }
 
 // FillFrom updates this config object, filling empty values with values from
@@ -43,6 +117,7 @@ func (c *config) FillFrom(o *config) {
 	if len(c.Alphabet) == 0 {
 		c.Alphabet = o.Alphabet
 	}
+	c.Regexes.FillFrom(o.Regexes)
 	c.Verbose = c.Verbose || o.Verbose
 }
 
@@ -59,6 +134,7 @@ func (c *config) Flags() []string {
 	if len(c.Alphabet) > 0 {
 		args = append(args, "-alphabet", c.Alphabet.String())
 	}
+	args = append(args, c.Regexes.Flags()...)
 	if c.Verbose {
 		args = append(args, "-verbose")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"reflect"
+	"strings"
 	"testing"
 	"testing/quick"
 	"time"
+	"unicode/utf8"
 
 	"github.com/abhinav/tmux-fastcopy/internal/iotest"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux"
@@ -15,13 +18,106 @@ import (
 	"github.com/maxatome/go-testdeep/td"
 )
 
+func TestMatcherDefaultRegexes(t *testing.T) {
+	t.Parallel()
+
+	matcher := make(matcher, 0, len(_defaultRegexes))
+	for name, reg := range _defaultRegexes {
+		m, err := compileRegexpMatcher(name, reg)
+		if !td.CmpNoError(t, err, "compile %q (%q)", name, reg) {
+			t.FailNow()
+		}
+		matcher = append(matcher, m)
+	}
+
+	tests := []struct {
+		desc string
+		give string
+		want []string
+	}{
+		{
+			desc: "ipv4",
+			give: "there's no place like 127.0.0.1",
+			want: []string{"127.0.0.1"},
+		},
+		{
+			desc: "gitsha/short",
+			give: "commit 016ca97 (origin/main, main)",
+			want: []string{"016ca97"},
+		},
+		{
+			desc: "gitsha/long",
+			give: "This reverts commit dbf2bb40bf8711e5d854c22d8bf19fc58da38cf2.",
+			want: []string{"dbf2bb40bf8711e5d854c22d8bf19fc58da38cf2"},
+		},
+		{
+			desc: "panic", // numbers, addresses, paths
+			give: joinLines(
+				"goroutine 36 [running]:",
+				"testing.tRunner.func1.2(0x1265c60, 0x13052c8)",
+				"        /usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go:1143 +0x332",
+			),
+			want: []string{
+				"0x1265c60", "0x13052c8", "0x332",
+				"1143",
+				"/usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go",
+			},
+		},
+		{
+			desc: "hexcolor/short",
+			give: "background-color: #eee",
+			want: []string{"#eee"},
+		},
+		{
+			desc: "hexcolor/long",
+			give: "background-color: #f8f8f0;",
+			want: []string{"#f8f8f0"},
+		},
+		{
+			desc: "uuid/upper",
+			give: "A13BBDE2-2FAB-40A3-B00C-949AC6EBDD79",
+			want: []string{"A13BBDE2-2FAB-40A3-B00C-949AC6EBDD79"},
+		},
+		{
+			desc: "uuid/lower",
+			give: "425a6a91-58aa-4027-8940-feecaaaece02",
+			want: []string{
+				"425a6a91-58aa-4027-8940-feecaaaece02",
+				// lower case UUID overlaps with other number
+				// and gitsha:
+				//   "425a6a91" "-4027" "-8940" "feecaaaece02"
+			},
+		},
+		{
+			desc: "date",
+			give: "2021-08-14 12:34 -0700",
+			want: []string{"2021-08-14", "-0700"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var got []string
+			for _, m := range matcher.Match(tt.give) {
+				got = append(got, tt.give[m.Start:m.End])
+			}
+
+			td.Cmp(t, got, td.Bag(td.Flatten(tt.want)))
+		})
+	}
+}
+
 func TestConfigFlags(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc string
-		give []string
-		want config
+		desc    string
+		give    []string
+		want    config
+		wantErr string
 	}{
 		{desc: "no args"}, // zero values
 		{
@@ -44,6 +140,53 @@ func TestConfigFlags(t *testing.T) {
 			give: []string{"-alphabet", "0123456789"},
 			want: config{Alphabet: "0123456789"},
 		},
+		{
+			desc:    "alphabet/too small",
+			give:    []string{"-alphabet", "a"},
+			wantErr: `alphabet must have at least two items`,
+		},
+		{
+			desc:    "alphabet/duplicate",
+			give:    []string{"-alphabet", "aaa"},
+			wantErr: "alphabet has duplicates",
+		},
+		{
+			desc: "regex/single",
+			give: []string{"-regex", "foo:bar"},
+			want: config{
+				Regexes: regexes{"foo": "bar"},
+			},
+		},
+		{
+			desc: "regex/multiple",
+			give: []string{
+				"-regex", "foo:bar",
+				"-regex", "baz:qux",
+			},
+			want: config{
+				Regexes: regexes{
+					"foo": "bar",
+					"baz": "qux",
+				},
+			},
+		},
+		{
+			desc:    "regex/no name",
+			give:    []string{"-regex", ":bar"},
+			wantErr: `regex must have a name`,
+		},
+		{
+			desc: "regex/no regex",
+			give: []string{"-regex", "bar:"},
+			want: config{
+				Regexes: regexes{"bar": ""},
+			},
+		},
+		{
+			desc:    "regex/wrong form",
+			give:    []string{"-regex", "foo"},
+			wantErr: `must be in the form NAME:REGEX`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -56,10 +199,19 @@ func TestConfigFlags(t *testing.T) {
 			fset.SetOutput(iotest.Writer(t))
 			cfg.RegisterFlags(fset)
 
-			td.CmpNoError(t, fset.Parse(tt.give))
-			td.Cmp(t, cfg, tt.want)
+			err := fset.Parse(tt.give)
+			if len(tt.wantErr) > 0 {
+				td.CmpError(t, err, "parse failure")
+				td.CmpContains(t, err.Error(), tt.wantErr)
+				return
+			}
 
-			t.Run("args", func(t *testing.T) {
+			td.Cmp(t, cfg, tt.want, "parse flags")
+
+			// The following turns the parsec cfg back into flags
+			// and tries again. This is worth trying only if an
+			// error was not expected in the original parse.
+			t.Run("Flags", func(t *testing.T) {
 				args := cfg.Flags()
 
 				fset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
@@ -99,6 +251,23 @@ func TestConfigTmuxOptions(t *testing.T) {
 			desc: "alphabet",
 			give: "@fastcopy-alphabet abc",
 			want: config{Alphabet: "abc"},
+		},
+		{
+			desc: "regexes",
+			give: joinLines(
+				// tmux show-options will escape the '\' in the
+				// string.
+				`@fastcopy-regex-phab-diff "D\\d{3,}"`,
+				`@fastcopy-regex-github-pr "github.com/\\w+/\\w+/pull/\\d+"`,
+				`@fastcopy-regex-hexcolor ""`,
+			),
+			want: config{
+				Regexes: regexes{
+					"phab-diff": `D\d{3,}`,
+					"github-pr": `github.com/\w+/\w+/pull/\d+`,
+					"hexcolor":  "",
+				},
+			},
 		},
 	}
 
@@ -142,11 +311,18 @@ func TestConfigMerge(t *testing.T) {
 					Action:   "bar",
 					Alphabet: "abc",
 					Verbose:  true,
+					Regexes: regexes{
+						"foo": "bar",
+					},
 				},
 				{
 					Pane:     "ignored",
 					Action:   "ignored",
 					Alphabet: "ignored",
+					Regexes: regexes{
+						"foo": "ignored",
+						"bar": "baz",
+					},
 				},
 			},
 			want: config{
@@ -154,6 +330,10 @@ func TestConfigMerge(t *testing.T) {
 				Action:   "bar",
 				Alphabet: "abc",
 				Verbose:  true,
+				Regexes: regexes{
+					"foo": "bar",
+					"bar": "baz",
+				},
 			},
 		},
 		{
@@ -163,12 +343,20 @@ func TestConfigMerge(t *testing.T) {
 				{Action: "bar"},
 				{Alphabet: "abc"},
 				{Verbose: true},
+				{Regexes: regexes{"foo": "bar"}},
+				{Regexes: regexes{"bar": "baz"}},
+				{Regexes: regexes{"foo": "ignored"}},
+				{Regexes: regexes{"bar": "ignored"}},
 			},
 			want: config{
 				Pane:     "foo",
 				Action:   "bar",
 				Alphabet: "abc",
 				Verbose:  true,
+				Regexes: regexes{
+					"foo": "bar",
+					"bar": "baz",
+				},
 			},
 		},
 	}
@@ -189,6 +377,8 @@ func TestConfigMerge(t *testing.T) {
 }
 
 func TestConfigFlagsQuickCheck(t *testing.T) {
+	t.Parallel()
+
 	// Make sure that config is always round-trippable because we need to
 	// the wrapper process to be able to send the exact same configuration
 	// down to the wrapped process.
@@ -200,7 +390,6 @@ func TestConfigFlagsQuickCheck(t *testing.T) {
 		}
 	}()
 
-	random := rand.New(rand.NewSource(seed))
 	quick.Check(func(give config) bool {
 		// Skip invalid alphabets.
 		if give.Alphabet.Validate() != nil {
@@ -216,11 +405,22 @@ func TestConfigFlagsQuickCheck(t *testing.T) {
 			return false
 		}
 
+		if len(give.Regexes) == 0 {
+			give.Regexes = nil // to make nil v non-nil map comparison easier
+		}
+
 		return td.Cmp(t, got, give)
-	}, &quick.Config{Rand: random})
+	}, &quick.Config{
+		Rand: rand.New(rand.NewSource(seed)),
+		Values: func(vs []reflect.Value, rand *rand.Rand) {
+			vs[0] = reflect.ValueOf(generateConfig(t, rand))
+		},
+	})
 }
 
 func TestUsageHasAllConfigFlags(t *testing.T) {
+	t.Parallel()
+
 	// We use _usage to write the user facing help. Make sure that every
 	// flag registered by RegisterFlags has a corresponding entry in
 	// _usage.
@@ -234,4 +434,82 @@ func TestUsageHasAllConfigFlags(t *testing.T) {
 			"flag %q should be documented", f.Name)
 	})
 
+}
+
+var (
+	_typeString = reflect.TypeOf("")
+	_typeBool   = reflect.TypeOf(true)
+)
+
+func generateConfig(t testing.TB, rand *rand.Rand) config {
+	return config{
+		Pane:     generateString(t, rand, 0, "generate pane"),
+		Action:   generateString(t, rand, 0, "generate action"),
+		Alphabet: generateAlphabet(t, rand),
+		Verbose:  generateValue(t, rand, _typeBool, "verbose").(bool),
+		Regexes:  generateRegexes(t, rand),
+	}
+}
+
+func generateAlphabet(t testing.TB, rand *rand.Rand) alphabet {
+	for {
+		alpha := generateString(t, rand, 2, "generate alphabet")
+
+		runes := make(map[rune]struct{})
+		for _, r := range alpha {
+			runes[r] = struct{}{}
+		}
+
+		if len(runes) < 2 {
+			continue // too short, try again
+		}
+
+		out := make([]rune, 0, len(runes))
+		for r := range runes {
+			out = append(out, r)
+		}
+		return alphabet(out)
+	}
+}
+
+func generateRegexes(t testing.TB, rand *rand.Rand) regexes {
+	count := rand.Intn(100)
+	m := make(regexes, count)
+	for i := 0; i < count; i++ {
+		var key string
+		for {
+			key = generateString(t, rand, 1, "regex name")
+			if strings.IndexByte(key, ':') < 0 {
+				break
+			}
+		}
+		value := generateString(t, rand, 1, "regex value")
+		m[key] = value
+	}
+	return m
+}
+
+func generateString(t testing.TB, rand *rand.Rand, minLength int, msg ...interface{}) string {
+	for {
+		s := generateValue(t, rand, _typeString, msg...).(string)
+		if len(s) < minLength {
+			continue
+		}
+		if !utf8.ValidString(s) {
+			continue
+		}
+		return s
+	}
+}
+
+func generateValue(t testing.TB, rand *rand.Rand, typ reflect.Type, msg ...interface{}) interface{} {
+	v, ok := quick.Value(typ, rand)
+	if !td.CmpTrue(t, ok, msg...) {
+		t.FailNow()
+	}
+	return v.Interface()
+}
+
+func joinLines(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
 }

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/abhinav/tmux-fastcopy/internal/iotest"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux/tmuxopt"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux/tmuxtest"
@@ -52,6 +53,7 @@ func TestConfigFlags(t *testing.T) {
 
 			var cfg config
 			fset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+			fset.SetOutput(iotest.Writer(t))
 			cfg.RegisterFlags(fset)
 
 			td.CmpNoError(t, fset.Parse(tt.give))
@@ -61,6 +63,7 @@ func TestConfigFlags(t *testing.T) {
 				args := cfg.Flags()
 
 				fset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+				fset.SetOutput(iotest.Writer(t))
 				var got config
 				got.RegisterFlags(fset)
 
@@ -205,6 +208,7 @@ func TestConfigFlagsQuickCheck(t *testing.T) {
 		}
 
 		flag := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+		flag.SetOutput(iotest.Writer(t))
 		var got config
 		got.RegisterFlags(flag)
 
@@ -222,6 +226,7 @@ func TestUsageHasAllConfigFlags(t *testing.T) {
 	// _usage.
 
 	fset := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	fset.SetOutput(iotest.Writer(t))
 	new(config).RegisterFlags(fset)
 
 	fset.VisitAll(func(f *flag.Flag) {

--- a/internal/iotest/writer.go
+++ b/internal/iotest/writer.go
@@ -1,0 +1,22 @@
+package iotest
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+var _newline = []byte("\n")
+
+// Writer builds an io.Writer that writes to the given testing.TB.
+func Writer(t testing.TB) io.Writer {
+	return &writer{t}
+}
+
+type writer struct{ t testing.TB }
+
+func (w *writer) Write(b []byte) (int, error) {
+	b = bytes.TrimSuffix(b, _newline)
+	w.t.Logf("%s", b)
+	return len(b), nil
+}

--- a/internal/iotest/writer_test.go
+++ b/internal/iotest/writer_test.go
@@ -1,0 +1,33 @@
+package iotest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+type fakeT struct {
+	*testing.T
+
+	Buffer bytes.Buffer
+}
+
+func (t *fakeT) Logf(msg string, args ...interface{}) {
+	fmt.Fprintln(&t.Buffer, fmt.Sprintf(msg, args...))
+	// println to make sure it ends with a newline
+}
+
+func TestWriter(t *testing.T) {
+	t.Parallel()
+
+	fakeT := fakeT{T: t}
+	w := Writer(&fakeT)
+	io.WriteString(w, "foo")
+	td.Cmp(t, fakeT.Buffer.String(), "foo\n")
+	// TODO: If we wanted this to be more accurate, we would have it buffer
+	// the input on newlines simillar to the log-based io.Writer. It
+	// doesn't matter here.
+}

--- a/internal/log/logtest/logger.go
+++ b/internal/log/logtest/logger.go
@@ -1,23 +1,13 @@
 package logtest
 
 import (
-	"bytes"
 	"testing"
 
+	"github.com/abhinav/tmux-fastcopy/internal/iotest"
 	"github.com/abhinav/tmux-fastcopy/internal/log"
 )
 
 // NewLogger builds a logger at debug level that writes to a testing.T.
 func NewLogger(t testing.TB) *log.Logger {
-	return log.New(&writer{t}).WithLevel(log.Debug)
-}
-
-var _newline = []byte("\n")
-
-type writer struct{ t testing.TB }
-
-func (w *writer) Write(b []byte) (int, error) {
-	b = bytes.TrimSuffix(b, _newline)
-	w.t.Logf("%s", b)
-	return len(b), nil
+	return log.New(iotest.Writer(t)).WithLevel(log.Debug)
 }

--- a/internal/paniclog/handle.go
+++ b/internal/paniclog/handle.go
@@ -30,5 +30,7 @@ func Handle(pval interface{}, w io.Writer) error {
 
 // Recover recovers a panic and appends it into the given error pointer.
 func Recover(err *error, w io.Writer) {
-	*err = Handle(recover(), w)
+	if pval := recover(); pval != nil {
+		*err = Handle(pval, w)
+	}
 }

--- a/internal/paniclog/handle_test.go
+++ b/internal/paniclog/handle_test.go
@@ -93,4 +93,19 @@ func TestRecover(t *testing.T) {
 
 		defer Recover(&err, &buff)
 	})
+
+	t.Run("no panic with error", func(t *testing.T) {
+		t.Parallel()
+
+		err := errors.New("great sadness")
+		var buff bytes.Buffer
+
+		defer func() {
+			td.CmpError(t, err)
+			td.CmpContains(t, err.Error(), "great sadness")
+			td.CmpEmpty(t, buff.String())
+		}()
+
+		defer Recover(&err, &buff)
+	})
 }

--- a/internal/ui/annotated_text.go
+++ b/internal/ui/annotated_text.go
@@ -57,7 +57,6 @@ var _ Widget = (*AnnotatedText)(nil)
 func (at *AnnotatedText) SetAnnotations(anns ...TextAnnotation) {
 	anns = append(make([]TextAnnotation, 0, len(anns)), anns...)
 	sort.Sort(byOffset(anns))
-	// TODO: detect overlaps?
 
 	at.mu.Lock()
 	at.anns = anns

--- a/main.go
+++ b/main.go
@@ -62,6 +62,18 @@ The following flags are available:
 		If there is no '{}', the selected text is sent over stdin.
 			-action pbcopy
 		Uses 'tmux set-buffer' by default.
+	-regex NAME:PATTERN
+		regular expressions to search for.
+		Name identifies the pattern. Add this option any number of
+		times.
+			-regex 'attr:\w+\.\w+'
+		Use prior names to replace or unset patterns.
+			-regex 'ipv4:'
+		Capture groups in the regex indicate the text to be copied,
+		defaulting to the whole string if there are no capture groups.
+			-regex 'gitsha:([0-9a-f]{7})[0-9a-f]{,33}'
+		Default set includes: ipv4, gitsha, hexaddr, hexcolor, int,
+		path, uuid.
 	-alphabet STRING
 		characters used to generate labels.
 			-alphabet "asdfghjkl;"  # qwerty home row

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"io"
 	"os"
 	"path/filepath"
@@ -46,7 +47,7 @@ func TestMainLogOverride(t *testing.T) {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}).Run([]string{"--help"})
-	td.CmpNoError(t, err)
+	td.Cmp(t, err, flag.ErrHelp)
 
 	body, err := os.ReadFile(logfile)
 	td.CmpNoError(t, err)

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+type matcher []*regexpMatcher
+
+func (rms matcher) Match(s string) []Range {
+	var ms []match
+	for _, m := range rms {
+		ms = m.AppendMatches(s, ms)
+	}
+	ms = rms.removeOverlaps(ms)
+
+	rs := make([]Range, len(ms))
+	for i, m := range ms {
+		rs[i] = m.Sel
+	}
+	return rs
+}
+
+func (rms matcher) removeOverlaps(ms []match) []match {
+	if len(ms) < 2 {
+		return ms
+	}
+
+	// Sort in ascending order by:
+	// - Starts earliest
+	// - Runs longest
+	sort.Slice(ms, func(i, j int) bool {
+		l, r := ms[i].Full, ms[j].Full
+
+		if l.Start < r.Start {
+			return true
+		}
+		if l.Start > r.Start {
+			return false
+		}
+
+		return l.Len() > r.Len()
+	})
+
+	out := ms[:1]
+	for _, m := range ms[1:] {
+		if m.Full.Start < out[len(out)-1].Full.End {
+			continue
+		}
+		out = append(out, m)
+	}
+
+	return out
+}
+
+type regexpMatcher struct {
+	name   string
+	regex  *regexp.Regexp
+	subexp int
+}
+
+// compileRegexpMatcher builds a regexpMatcher with the provided name and
+// regular expression.
+func compileRegexpMatcher(name, s string) (*regexpMatcher, error) {
+	if len(s) == 0 {
+		return &regexpMatcher{name: name}, nil
+	}
+
+	re, err := regexp.Compile(s)
+	if err != nil {
+		return nil, err
+	}
+
+	n := 0
+	if re.NumSubexp() > 0 {
+		n++
+	}
+
+	return &regexpMatcher{
+		regex:  re,
+		subexp: n,
+		name:   name,
+	}, nil
+}
+
+func (rm *regexpMatcher) Name() string {
+	return rm.name
+}
+
+func (rm *regexpMatcher) String() string {
+	return fmt.Sprintf("%v:%v", rm.name, rm.regex)
+}
+
+type match struct {
+	// Full matched area.
+	Full Range
+
+	// Selected portion that will be copied.
+	Sel Range
+}
+
+func (rm *regexpMatcher) AppendMatches(s string, ms []match) []match {
+	if rm.regex == nil {
+		return ms
+	}
+	for _, m := range rm.regex.FindAllStringSubmatchIndex(s, -1) {
+		ms = append(ms, match{
+			Full: Range{Start: m[0], End: m[1]},
+			Sel:  Range{Start: m[2*rm.subexp], End: m[2*rm.subexp+1]},
+		})
+	}
+	return ms
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func TestRegexpMatcher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
+		regex    string
+		s        string
+		wantSel  []string
+		wantFull []string
+	}{
+		{
+			desc:     "empty",
+			s:        "foo",
+			wantSel:  []string{},
+			wantFull: []string{},
+		},
+		{
+			desc:     "full match",
+			regex:    "a(?:b|c)",
+			s:        "foo ab bar ac",
+			wantSel:  []string{"ab", "ac"},
+			wantFull: []string{"ab", "ac"},
+		},
+		{
+			desc:     "subexp match",
+			regex:    "a(b|c)",
+			s:        "foo ab bar ac",
+			wantSel:  []string{"b", "c"},
+			wantFull: []string{"ab", "ac"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := compileRegexpMatcher(tt.desc, tt.regex)
+			if !td.CmpNoError(t, err, "compile regex") {
+				return
+			}
+
+			td.CmpNotPanic(t, func() {
+				_ = m.String()
+			}, "String")
+
+			t.Run("Name", func(t *testing.T) {
+				td.Cmp(t, m.Name(), tt.desc)
+			})
+
+			t.Run("Matches", func(t *testing.T) {
+				ms := m.AppendMatches(tt.s, nil)
+				gotSel := make([]string, len(ms))
+				gotFull := make([]string, len(ms))
+				for i, m := range ms {
+					gotSel[i] = tt.s[m.Sel.Start:m.Sel.End]
+					gotFull[i] = tt.s[m.Full.Start:m.Full.End]
+				}
+
+				td.Cmp(t, gotSel, tt.wantSel)
+				td.Cmp(t, gotFull, tt.wantFull)
+			})
+		})
+	}
+}

--- a/widget.go
+++ b/widget.go
@@ -15,6 +15,11 @@ import (
 // subslice of the text.
 type Range struct{ Start, End int }
 
+// Len reports the length of this range.
+func (r *Range) Len() int {
+	return r.End - r.Start
+}
+
 // Style configures the display style of the widget.
 type Style struct {
 	Normal       tcell.Style // normal text

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/abhinav/tmux-fastcopy/internal/envtest"
+	"github.com/abhinav/tmux-fastcopy/internal/iotest"
 	"github.com/abhinav/tmux-fastcopy/internal/log/logtest"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux/tmuxtest"
@@ -65,6 +66,7 @@ func TestWrapper(t *testing.T) {
 			mockTmux.EXPECT().NewSession(gomock.Any()).
 				Do(func(req tmux.NewSessionRequest) {
 					fset := flag.NewFlagSet(_name, flag.ContinueOnError)
+					fset.SetOutput(iotest.Writer(t))
 
 					var gotConfig config
 					gotConfig.RegisterFlags(fset)


### PR DESCRIPTION
Adds support for custom regular expressions. At its core, this
functionality is supported by the CLI flag:

    --regex NAME:REGEX

Where `NAME` uniquely identifies this pattern and will overwrite prior
instances of this name (making it possible to override default regular
expressions).

However, most users will probably use the tmux.conf:

    set -g @fastcopy-regex-NAME REGEX

Where `NAME` and `REGEX` are specified by the user.

In implementing this, I ran into some issues with overlapping matches
from regular expressions, so this addresses that too. Overlapping
regular expressions are cleaned up in favor of the longest matches.

Finally, if a regular expression has a capture group `(...)`, then the
first capture group will be the captured text rather than the whole
match. This makes it easier to match on surrounding context.

Resolves #14
