### PR TITLE
Default action should write to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- The default action `tmux set-buffer` now includes the `-w` flag which makes
+  tmux write to the client's clipboard.
+
 ## 0.3.1 - 2021-08-23
 ### Fixed
 - Make path regex more accurate and avoid matching URLs.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Change how text is copied with this action.
 
 **Default**:
 
-    set-option -g @fastcopy-action 'tmux set-buffer -- {}'
+    set-option -g @fastcopy-action 'tmux set-buffer -w -- {}'
 
 The string specifies the command to run with the selection, as well as the
 arguments for the command. The special argument `{}` acts as a placeholder for

--- a/action.go
+++ b/action.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	_placeholderArg = "{}"
-	_defaultAction  = "tmux set-buffer -- {}"
+	_defaultAction  = "tmux set-buffer -w -- {}"
 )
 
 type actionFactory struct {

--- a/main.go
+++ b/main.go
@@ -58,10 +58,10 @@ The following flags are available:
 	-action COMMAND
 		command and arguments that handle the selection.
 		The first '{}' in the argument list is the selected text.
-			-action 'tmux set-buffer -- {}'  # default
+			-action 'tmux set-buffer -w -- {}'  # default
 		If there is no '{}', the selected text is sent over stdin.
 			-action pbcopy
-		Uses 'tmux set-buffer' by default.
+		Uses 'tmux set-buffer -w' by default.
 	-regex NAME:PATTERN
 		regular expressions to search for.
 		Name identifies the pattern. Add this option any number of


### PR DESCRIPTION
`tmux set-buffer` needs the `-w` flag to write to the client's clipboard.
