### PR TITLE
make: Use MAKEFILE_LIST to determine path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ STATICCHECK = $(BIN)/staticcheck
 EXTRACT_CHANGELOG = $(BIN)/extract-changelog
 TOOLS = $(GOLINT) $(STATICCHECK) $(MOCKGEN) $(EXTRACT_CHANGELOG)
 
-export GOBIN ?= $(shell pwd)/$(BIN)
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export GOBIN ?= $(PROJECT_ROOT)/$(BIN)
 
 .PHONY: all
 all: build lint test


### PR DESCRIPTION
The `pwd` approach doesn't work in a multi-makefile situation.
MAKEFILE_LIST will always give a path relative to the current Makefile.
