### PR TITLE
Add -log and -tmux flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add back `-log` flag. Use this flag to specify the destination for log
+  messages.
+
 ### Fixed
 - The default action `tmux set-buffer` now includes the `-w` flag which makes
   tmux write to the client's clipboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add back `-log` flag. Use this flag to specify the destination for log
   messages.
+- Add `-tmux` flag to specify the location of the tmux executable.
 
 ### Fixed
 - The default action `tmux set-buffer` now includes the `-w` flag which makes

--- a/action.go
+++ b/action.go
@@ -9,10 +9,7 @@ import (
 	shellwords "github.com/mattn/go-shellwords"
 )
 
-const (
-	_placeholderArg = "{}"
-	_defaultAction  = "tmux set-buffer -w -- {}"
-)
+const _placeholderArg = "{}"
 
 type actionFactory struct {
 	Log *log.Logger

--- a/app.go
+++ b/app.go
@@ -22,7 +22,7 @@ type app struct {
 
 // Run runs the application with the provided configuration.
 func (app *app) Run(cfg *config) error {
-	cfg.FillFrom(&_defaultConfig)
+	cfg.FillFrom(defaultConfig(cfg))
 
 	matcher := make(matcher, 0, len(cfg.Regexes))
 	for name, reg := range cfg.Regexes {

--- a/config.go
+++ b/config.go
@@ -88,6 +88,7 @@ type config struct {
 	Alphabet alphabet
 	Verbose  bool
 	Regexes  regexes
+	LogFile  string
 }
 
 func (c *config) RegisterFlags(flag *flag.FlagSet) {
@@ -97,6 +98,7 @@ func (c *config) RegisterFlags(flag *flag.FlagSet) {
 	flag.Var(&c.Alphabet, "alphabet", "")
 	flag.Var(&c.Regexes, "regex", "")
 	flag.BoolVar(&c.Verbose, "verbose", false, "")
+	flag.StringVar(&c.LogFile, "log", "", "")
 }
 
 func (c *config) RegisterOptions(load *tmuxopt.Loader) {
@@ -116,6 +118,9 @@ func (c *config) FillFrom(o *config) {
 	}
 	if len(c.Alphabet) == 0 {
 		c.Alphabet = o.Alphabet
+	}
+	if len(c.LogFile) == 0 {
+		c.LogFile = o.LogFile
 	}
 	c.Regexes.FillFrom(o.Regexes)
 	c.Verbose = c.Verbose || o.Verbose
@@ -137,6 +142,9 @@ func (c *config) Flags() []string {
 	args = append(args, c.Regexes.Flags()...)
 	if c.Verbose {
 		args = append(args, "-verbose")
+	}
+	if len(c.LogFile) > 0 {
+		args = append(args, "-log", c.LogFile)
 	}
 	return args
 }

--- a/config.go
+++ b/config.go
@@ -21,12 +21,6 @@ var _defaultRegexes = map[string]string{
 	"isodate":  `\d{4}-\d{2}-\d{2}`,
 }
 
-var _defaultConfig = config{
-	Action:   _defaultAction,
-	Alphabet: _defaultAlphabet,
-	Regexes:  _defaultRegexes,
-}
-
 // regexes is a map from regex name to body. If body is empty, this regex
 // should be skipped.
 type regexes map[string]string
@@ -88,7 +82,17 @@ type config struct {
 	Alphabet alphabet
 	Verbose  bool
 	Regexes  regexes
+	Tmux     string
 	LogFile  string
+}
+
+// Generates a new default configuration.
+func defaultConfig(cfg *config) *config {
+	return &config{
+		Action:   fmt.Sprintf("%v set-buffer -w -- {}", cfg.Tmux),
+		Alphabet: _defaultAlphabet,
+		Regexes:  _defaultRegexes,
+	}
 }
 
 func (c *config) RegisterFlags(flag *flag.FlagSet) {
@@ -99,6 +103,7 @@ func (c *config) RegisterFlags(flag *flag.FlagSet) {
 	flag.Var(&c.Regexes, "regex", "")
 	flag.BoolVar(&c.Verbose, "verbose", false, "")
 	flag.StringVar(&c.LogFile, "log", "", "")
+	flag.StringVar(&c.Tmux, "tmux", "tmux", "")
 }
 
 func (c *config) RegisterOptions(load *tmuxopt.Loader) {
@@ -121,6 +126,9 @@ func (c *config) FillFrom(o *config) {
 	}
 	if len(c.LogFile) == 0 {
 		c.LogFile = o.LogFile
+	}
+	if len(c.Tmux) == 0 {
+		c.Tmux = o.Tmux
 	}
 	c.Regexes.FillFrom(o.Regexes)
 	c.Verbose = c.Verbose || o.Verbose
@@ -145,6 +153,9 @@ func (c *config) Flags() []string {
 	}
 	if len(c.LogFile) > 0 {
 		args = append(args, "-log", c.LogFile)
+	}
+	if len(c.Tmux) > 0 {
+		args = append(args, "-tmux", c.Tmux)
 	}
 	return args
 }

--- a/config_test.go
+++ b/config_test.go
@@ -201,6 +201,11 @@ func TestConfigFlags(t *testing.T) {
 			give:    []string{"-regex", "foo"},
 			wantErr: `must be in the form NAME:REGEX`,
 		},
+		{
+			desc: "log",
+			give: []string{"-log", "foo.txt"},
+			want: config{LogFile: "foo.txt"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -323,6 +328,7 @@ func TestConfigMerge(t *testing.T) {
 					Action:   "bar",
 					Alphabet: "abc",
 					Verbose:  true,
+					LogFile:  "foo.txt",
 					Regexes: regexes{
 						"foo": "bar",
 					},
@@ -331,6 +337,7 @@ func TestConfigMerge(t *testing.T) {
 					Pane:     "ignored",
 					Action:   "ignored",
 					Alphabet: "ignored",
+					LogFile:  "ignored.txt",
 					Regexes: regexes{
 						"foo": "ignored",
 						"bar": "baz",
@@ -342,6 +349,7 @@ func TestConfigMerge(t *testing.T) {
 				Action:   "bar",
 				Alphabet: "abc",
 				Verbose:  true,
+				LogFile:  "foo.txt",
 				Regexes: regexes{
 					"foo": "bar",
 					"bar": "baz",
@@ -359,6 +367,7 @@ func TestConfigMerge(t *testing.T) {
 				{Regexes: regexes{"bar": "baz"}},
 				{Regexes: regexes{"foo": "ignored"}},
 				{Regexes: regexes{"bar": "ignored"}},
+				{LogFile: "foo.txt"},
 			},
 			want: config{
 				Pane:     "foo",
@@ -369,6 +378,7 @@ func TestConfigMerge(t *testing.T) {
 					"foo": "bar",
 					"bar": "baz",
 				},
+				LogFile: "foo.txt",
 			},
 		},
 	}
@@ -460,6 +470,7 @@ func generateConfig(t testing.TB, rand *rand.Rand) config {
 		Alphabet: generateAlphabet(t, rand),
 		Verbose:  generateValue(t, rand, _typeBool, "verbose").(bool),
 		Regexes:  generateRegexes(t, rand),
+		LogFile:  generateString(t, rand, 0, "generate logFile"),
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -133,26 +133,29 @@ func TestConfigFlags(t *testing.T) {
 		want    config
 		wantErr string
 	}{
-		{desc: "no args"}, // zero values
+		{
+			desc: "no args",
+			want: config{Tmux: "tmux"},
+		},
 		{
 			desc: "pane",
 			give: []string{"--pane", "42"},
-			want: config{Pane: "42"},
+			want: config{Pane: "42", Tmux: "tmux"},
 		},
 		{
 			desc: "verbose",
 			give: []string{"--verbose"},
-			want: config{Verbose: true},
+			want: config{Verbose: true, Tmux: "tmux"},
 		},
 		{
 			desc: "action",
 			give: []string{"-action", "pbcopy"},
-			want: config{Action: "pbcopy"},
+			want: config{Action: "pbcopy", Tmux: "tmux"},
 		},
 		{
 			desc: "alphabet",
 			give: []string{"-alphabet", "0123456789"},
-			want: config{Alphabet: "0123456789"},
+			want: config{Alphabet: "0123456789", Tmux: "tmux"},
 		},
 		{
 			desc:    "alphabet/too small",
@@ -169,6 +172,7 @@ func TestConfigFlags(t *testing.T) {
 			give: []string{"-regex", "foo:bar"},
 			want: config{
 				Regexes: regexes{"foo": "bar"},
+				Tmux:    "tmux",
 			},
 		},
 		{
@@ -182,6 +186,7 @@ func TestConfigFlags(t *testing.T) {
 					"foo": "bar",
 					"baz": "qux",
 				},
+				Tmux: "tmux",
 			},
 		},
 		{
@@ -194,6 +199,7 @@ func TestConfigFlags(t *testing.T) {
 			give: []string{"-regex", "bar:"},
 			want: config{
 				Regexes: regexes{"bar": ""},
+				Tmux:    "tmux",
 			},
 		},
 		{
@@ -204,7 +210,12 @@ func TestConfigFlags(t *testing.T) {
 		{
 			desc: "log",
 			give: []string{"-log", "foo.txt"},
-			want: config{LogFile: "foo.txt"},
+			want: config{LogFile: "foo.txt", Tmux: "tmux"},
+		},
+		{
+			desc: "tmux",
+			give: []string{"-tmux", "/usr/bin/tmux"},
+			want: config{Tmux: "/usr/bin/tmux"},
 		},
 	}
 
@@ -338,6 +349,7 @@ func TestConfigMerge(t *testing.T) {
 					Action:   "ignored",
 					Alphabet: "ignored",
 					LogFile:  "ignored.txt",
+					Tmux:     "/usr/bin/tmux",
 					Regexes: regexes{
 						"foo": "ignored",
 						"bar": "baz",
@@ -350,6 +362,7 @@ func TestConfigMerge(t *testing.T) {
 				Alphabet: "abc",
 				Verbose:  true,
 				LogFile:  "foo.txt",
+				Tmux:     "/usr/bin/tmux",
 				Regexes: regexes{
 					"foo": "bar",
 					"bar": "baz",
@@ -368,6 +381,7 @@ func TestConfigMerge(t *testing.T) {
 				{Regexes: regexes{"foo": "ignored"}},
 				{Regexes: regexes{"bar": "ignored"}},
 				{LogFile: "foo.txt"},
+				{Tmux: "/usr/local/bin/tmux"},
 			},
 			want: config{
 				Pane:     "foo",
@@ -379,6 +393,7 @@ func TestConfigMerge(t *testing.T) {
 					"bar": "baz",
 				},
 				LogFile: "foo.txt",
+				Tmux:    "/usr/local/bin/tmux",
 			},
 		},
 	}
@@ -471,6 +486,7 @@ func generateConfig(t testing.TB, rand *rand.Rand) config {
 		Verbose:  generateValue(t, rand, _typeBool, "verbose").(bool),
 		Regexes:  generateRegexes(t, rand),
 		LogFile:  generateString(t, rand, 0, "generate logFile"),
+		Tmux:     generateString(t, rand, 1, "generate tmux"),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -105,6 +105,10 @@ The following flags are available:
 		characters used to generate labels.
 			-alphabet "asdfghjkl;"  # qwerty home row
 		Uses the English alphabet by default.
+	-tmux PATH
+		path to tmux executable.
+			-tmux /usr/bin/tmux
+		Searches $PATH for tmux by default.
 	-log FILE
 		file to write logs to.
 		Uses stderr by default.
@@ -138,7 +142,7 @@ func (cmd *mainCmd) Run(cfg *config) (err error) {
 		cmd.Stderr = f
 	}
 
-	tmuxDriver := cmd.newTmuxDriver("tmux") // TODO cfg.Tmux
+	tmuxDriver := cmd.newTmuxDriver(cfg.Tmux)
 
 	// If we're wrapped, wait to send the done signal *after* writing the
 	// panic.

--- a/wrap.go
+++ b/wrap.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	_parentPIDEnv = "TMUX_FASTCOPY_WRAPPED_BY"
-	_logfileEnv   = "TMUX_FASTCOPY_LOG_FILE"
 	_signalPrefix = "TMUX_FASTCOPY_WRAPPER_"
 )
 
@@ -81,6 +80,7 @@ func (w *wrapper) Run(cfg *config) (err error) {
 		return fmt.Errorf("load options: %v", err)
 	}
 
+	cfg.LogFile = tmpLog.Name()
 	cfg.FillFrom(&tmuxCfg)
 
 	parent := strconv.Itoa(w.Getpid())
@@ -90,7 +90,6 @@ func (w *wrapper) Run(cfg *config) (err error) {
 		Detached: true,
 		Env: []string{
 			fmt.Sprintf("%v=%v", _parentPIDEnv, w.Getpid()),
-			fmt.Sprintf("%v=%v", _logfileEnv, tmpLog.Name()),
 		},
 		Command: append([]string{exe}, cfg.Flags()...),
 	}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -73,6 +73,12 @@ func TestWrapper(t *testing.T) {
 					gotConfig.RegisterFlags(fset)
 
 					require.NoError(t, fset.Parse(req.Command[1:]))
+
+					// zero out log file for comparison.
+					if assert.NotEmpty(t, gotConfig.LogFile, "log file must be specified") {
+						gotConfig.LogFile = ""
+					}
+
 					assert.Equal(t, tt.wantConfig, gotConfig)
 				})
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -37,6 +37,7 @@ func TestWrapper(t *testing.T) {
 			},
 			wantConfig: config{
 				Pane: "%1",
+				Tmux: "tmux",
 			},
 		},
 		{
@@ -54,6 +55,7 @@ func TestWrapper(t *testing.T) {
 				Pane:     "%3",
 				Action:   "pbcopy",
 				Alphabet: alphabet("asdfghjkl"),
+				Tmux:     "tmux",
 			},
 		},
 	}


### PR DESCRIPTION
Add `-log` and `-tmux` flags to specify the location of the log file and the
tmux executable. `-log` deprecates the `TMUX_FASTCOPY_LOG` environment
variable.
