### PR TITLE
Support Tmux 3.1c

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        tmux-version: ["3.2a"] # , "3.1", "3.0"]
+        tmux-version: ["3.2a", "3.1c"]
 
     name: Integration Test / Tmux ${{ matrix.tmux-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages.
 - Add `-tmux` flag to specify the location of the tmux executable.
 
-### Fixed
-- The default action `tmux set-buffer` now includes the `-w` flag which makes
-  tmux write to the client's clipboard.
-
 ## 0.3.1 - 2021-08-23
 ### Fixed
 - Make path regex more accurate and avoid matching URLs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages.
 - Add `-tmux` flag to specify the location of the tmux executable.
 
+### Changed
+- Support Tmux 3.1. Previously, tmux-fastcopy required at least Tmux 3.2.
+
 ## 0.3.1 - 2021-08-23
 ### Fixed
 - Make path regex more accurate and avoid matching URLs.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Before you install, make sure you are running a supported version of tmux.
 $ tmux -V
 ```
 
-Supported versions: >= 3.2
+Supported versions: >= 3.1
 
 The following methods of installation are available:
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Change how text is copied with this action.
 
 **Default**:
 
-    set-option -g @fastcopy-action 'tmux set-buffer -w -- {}'
+    set-option -g @fastcopy-action 'tmux set-buffer -- {}'
 
 The string specifies the command to run with the selection, as well as the
 arguments for the command. The special argument `{}` acts as a placeholder for

--- a/config.go
+++ b/config.go
@@ -89,7 +89,7 @@ type config struct {
 // Generates a new default configuration.
 func defaultConfig(cfg *config) *config {
 	return &config{
-		Action:   fmt.Sprintf("%v set-buffer -w -- {}", cfg.Tmux),
+		Action:   fmt.Sprintf("%v set-buffer -- {}", cfg.Tmux),
 		Alphabet: _defaultAlphabet,
 		Regexes:  _defaultRegexes,
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -92,7 +92,7 @@ func Test(t *testing.T) {
 		break
 	}
 
-	require.NotEmpty(t, got, "file %q not found after 5 seconds")
+	require.NotEmpty(t, got, "file %q not found after 5 seconds", gotFile)
 
 	t.Logf("got %q", got)
 	assert.Contains(t, []string{
@@ -121,7 +121,7 @@ func newFakeEnv(t testing.TB) *fakeEnv {
 	require.NoError(t, os.Mkdir(tmpDir, 01755), "set up tmpDir")
 
 	logFile := filepath.Join(root, "log.txt")
-	defer func() {
+	t.Cleanup(func() {
 		if !t.Failed() {
 			return
 		}
@@ -132,7 +132,7 @@ func newFakeEnv(t testing.TB) *fakeEnv {
 		} else {
 			t.Logf("tmux-fastcopy log:\n%s", got)
 		}
-	}()
+	})
 
 	tmux, err := exec.LookPath("tmux")
 	require.NoError(t, err, "find tmux")

--- a/internal/tmux/shell_test.go
+++ b/internal/tmux/shell_test.go
@@ -54,9 +54,11 @@ func TestNewSessionArgs(t *testing.T) {
 		{
 			desc: "env",
 			give: NewSessionRequest{
-				Env: []string{"FOO=bar", "BAZ=qux"},
+				Env:     []string{"FOO=bar", "BAZ=qux"},
+				Command: []string{"/bin/bash"},
 			},
-			want: []string{"new-session", "-e", "FOO=bar", "-e", "BAZ=qux"},
+			want: []string{"new-session",
+				"/usr/bin/env", "FOO=bar", "BAZ=qux", "/bin/bash"},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -85,10 +85,10 @@ The following flags are available:
 	-action COMMAND
 		command and arguments that handle the selection.
 		The first '{}' in the argument list is the selected text.
-			-action 'tmux set-buffer -w -- {}'  # default
+			-action 'tmux set-buffer -- {}'  # default
 		If there is no '{}', the selected text is sent over stdin.
 			-action pbcopy
-		Uses 'tmux set-buffer -w' by default.
+		Uses 'tmux set-buffer' by default.
 	-regex NAME:PATTERN
 		regular expressions to search for.
 		Name identifies the pattern. Add this option any number of


### PR DESCRIPTION
The `-e` flag of `new-session` was added in Tmux 3.2. We can support
tmux 3.1 by instead shelling out to `/usr/bin/env` and using that to set
the environment variables.

