### PR TITLE
Prepare release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.0 - 2021-09-06
+Highlight: The minimum required version of Tmux was lowered to 3.0.
+
 ### Added
 - Add back `-log` flag. Use this flag to specify the destination for log
   messages.

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 
 IMPORTPATH=github.com/abhinav/tmux-fastcopy
 NAME=tmux-fastcopy
-VERSION=0.3.1
+VERSION=0.4.0
 
 while getopts 'c:' opt; do
 	case "$opt" in


### PR DESCRIPTION
Release v0.4.0 of tmux-fastcopy with support for tmux 3.0.