### PR TITLE
Support Tmux 3.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        tmux-version: ["3.2a", "3.1c"]
+        tmux-version: ["3.2a", "3.1c", "3.0a"]
 
     name: Integration Test / Tmux ${{ matrix.tmux-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `-tmux` flag to specify the location of the tmux executable.
 
 ### Changed
-- Support Tmux 3.1. Previously, tmux-fastcopy required at least Tmux 3.2.
+- Support Tmux 3.0. Previously, tmux-fastcopy required at least Tmux 3.2.
 
 ## 0.3.1 - 2021-08-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Before you install, make sure you are running a supported version of tmux.
 $ tmux -V
 ```
 
-Supported versions: >= 3.1
+Supported versions: >= 3.0
 
 The following methods of installation are available:
 

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -2,4 +2,4 @@ PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/..
 
 .PHONY: test
 test: *.go
-	PATH=$(PROJECT_ROOT)/bin:$$PATH go test -v
+	PATH=$(PROJECT_ROOT)/bin:$$PATH go test -v -timeout 30s

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -19,6 +19,9 @@ type Driver interface {
 	// SwapPane runs the tmux swap-pane command.
 	SwapPane(SwapPaneRequest) error
 
+	// ResizePane runs the tmux resize-pane command.
+	ResizePane(ResizePaneRequest) error
+
 	// ResizeWindow runs the tmux resize-window command.
 	ResizeWindow(ResizeWindowRequest) error
 
@@ -112,17 +115,12 @@ type SwapPaneRequest struct {
 
 	// Destination pane to swap the source with.
 	Destination string
-
-	// MaintainZoom specifies that if the window was zoomed, it should
-	// remain zoomed.
-	MaintainZoom bool
 }
 
 func (r SwapPaneRequest) String() string {
 	var b stringobj.Builder
 	b.Put("source", r.Source)
 	b.Put("destination", r.Destination)
-	b.Put("maintainZoom", r.MaintainZoom)
 	return b.String()
 }
 
@@ -148,5 +146,18 @@ type ShowOptionsRequest struct {
 func (r ShowOptionsRequest) String() string {
 	var b stringobj.Builder
 	b.Put("global", r.Global)
+	return b.String()
+}
+
+// ResizePaneRequest specifies the parameters for a resize-pane command.
+type ResizePaneRequest struct {
+	Target     string // target pane
+	ToggleZoom bool   // whether to toggle zoom
+}
+
+func (r ResizePaneRequest) String() string {
+	var b stringobj.Builder
+	b.Put("target", r.Target)
+	b.Put("toggleZoom", r.ToggleZoom)
 	return b.String()
 }

--- a/internal/tmux/inspect.go
+++ b/internal/tmux/inspect.go
@@ -25,6 +25,7 @@ type PaneInfo struct {
 	Width, Height  int
 	Mode           PaneMode
 	ScrollPosition int
+	WindowZoomed   bool
 }
 
 func (i *PaneInfo) String() string {
@@ -57,7 +58,8 @@ var (
 		Then: tmuxfmt.Var("scroll_position"),
 		Else: tmuxfmt.Int(0),
 	}
-	_windowID = tmuxfmt.Var("window_id")
+	_windowID     = tmuxfmt.Var("window_id")
+	_windowZoomed = tmuxfmt.Var("window_zoomed_flag")
 )
 
 // InspectPane inspects a tmux pane and reports information about it. The
@@ -74,6 +76,7 @@ func InspectPane(driver Driver, identifier string) (*PaneInfo, error) {
 	fc.IntVar(&info.Height, _paneHeight)
 	fc.StringVar((*string)(&info.Mode), _paneMode)
 	fc.IntVar(&info.ScrollPosition, _paneScrollPosition)
+	fc.BoolVar(&info.WindowZoomed, _windowZoomed)
 
 	msg, parse := fc.Prepare()
 	out, err := driver.DisplayMessage(DisplayMessageRequest{

--- a/internal/tmux/shell.go
+++ b/internal/tmux/shell.go
@@ -176,14 +176,27 @@ func (s *ShellDriver) SwapPane(req SwapPaneRequest) error {
 	if s := req.Source; len(s) > 0 {
 		args = append(args, "-s", s)
 	}
-	if req.MaintainZoom {
+
+	cmd := s.cmd(args...)
+	defer s.errorWriter(&cmd.Stdout, &cmd.Stderr)()
+
+	s.log.Debugf("swap pane: %v", req)
+	return s.run.Run(cmd)
+}
+
+// ResizePane runs the resize-pane command.
+func (s *ShellDriver) ResizePane(req ResizePaneRequest) error {
+	s.init()
+
+	args := []string{"resize-pane", "-t", req.Target}
+	if req.ToggleZoom {
 		args = append(args, "-Z")
 	}
 
 	cmd := s.cmd(args...)
 	defer s.errorWriter(&cmd.Stdout, &cmd.Stderr)()
 
-	s.log.Debugf("swap pane: %v", req)
+	s.log.Debugf("resize pane: %v", req)
 	return s.run.Run(cmd)
 }
 

--- a/internal/tmux/shell_test.go
+++ b/internal/tmux/shell_test.go
@@ -199,11 +199,6 @@ func TestSwapPaneArgs(t *testing.T) {
 			give: SwapPaneRequest{Source: "%43", Destination: "%42"},
 			want: []string{"swap-pane", "-t", "%42", "-s", "%43"},
 		},
-		{
-			desc: "zoom",
-			give: SwapPaneRequest{Destination: "%42", MaintainZoom: true},
-			want: []string{"swap-pane", "-t", "%42", "-Z"},
-		},
 	}
 
 	for _, tt := range tests {
@@ -219,6 +214,44 @@ func TestSwapPaneArgs(t *testing.T) {
 				log: logtest.NewLogger(t),
 			}
 			err := driver.SwapPane(tt.give)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestResizePaneArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give ResizePaneRequest
+		want []string
+	}{
+		{
+			desc: "minimal",
+			give: ResizePaneRequest{Target: "%42"},
+			want: []string{"resize-pane", "-t", "%42"},
+		},
+		{
+			desc: "source",
+			give: ResizePaneRequest{Target: "%43", ToggleZoom: true},
+			want: []string{"resize-pane", "-t", "%43", "-Z"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			r := newFakeRunner(t)
+			r.ExpectOutput("tmux", tt.want...)
+
+			driver := ShellDriver{
+				run: r.Runner(),
+				log: logtest.NewLogger(t),
+			}
+			err := driver.ResizePane(tt.give)
 			assert.NoError(t, err)
 		})
 	}

--- a/internal/tmux/tmuxtest/mocks.go
+++ b/internal/tmux/tmuxtest/mocks.go
@@ -79,6 +79,20 @@ func (mr *MockDriverMockRecorder) NewSession(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockDriver)(nil).NewSession), arg0)
 }
 
+// ResizePane mocks base method.
+func (m *MockDriver) ResizePane(arg0 tmux.ResizePaneRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResizePane", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResizePane indicates an expected call of ResizePane.
+func (mr *MockDriverMockRecorder) ResizePane(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizePane", reflect.TypeOf((*MockDriver)(nil).ResizePane), arg0)
+}
+
 // ResizeWindow mocks base method.
 func (m *MockDriver) ResizeWindow(arg0 tmux.ResizeWindowRequest) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The `-Z` flag for `swap-pane` was added in Tmux 3.1. We can do without
it by explicitly resizing the window if it's zoomed. This will cause
a slight flicker for zoomed windows, but it might be an acceptable
tradeoff.