### PR TITLE
Use load-buffer as the default action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Change default action to `tmux load-buffer -`. This eliminates risk of
+  hitting ARG_MAX with `set-buffer`--however unlikely that was.
+
 ## 0.4.0 - 2021-09-06
 Highlight: The minimum required version of Tmux was lowered to 3.0.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you'd like to copy the text to your system clipboard, and you're using
 tmux >= 3.2, add the following to your .tmux.conf:
 
     set-option -g set-clipboard on
-    set-option -g @fastcopy-action 'tmux set-buffer -w -- {}'
+    set-option -g @fastcopy-action 'tmux load-buffer -'
 
 See [How do I copy text to my clipboard?](#clipboard) for older versions of
 tmux.
@@ -145,7 +145,7 @@ Change how text is copied with this action.
 
 **Default**:
 
-    set-option -g @fastcopy-action 'tmux set-buffer -- {}'
+    set-option -g @fastcopy-action 'tmux load-buffer -'
 
 The string specifies the command to run with the selection, as well as the
 arguments for the command. The special argument `{}` acts as a placeholder for
@@ -245,15 +245,15 @@ them to a blank string.
 ### <a id="clipboard"></a> How do I copy text to my clipboard?
 
 To copy text to your system clipboard, you can use tmux's `set-clipboard`
-option and change the action to `tmux set-buffer -w` if you're using
+option and change the action to `tmux load-buffer -w -` if you're using
 at least tmux 3.2.
 
     set-option -g set-clipboard on
-    set-option -g @fastcopy-action 'tmux set-buffer -w -- {}'
+    set-option -g @fastcopy-action 'tmux load-buffer -w -'
 
-With this option set, and the `-w` flag for `set-buffer`, tmux will use the OSC52
-escape sequence to directly set the clipboard for your terminal emulator--it
-should work even through an SSH session. Check out
+With this option set, and the `-w` flag for `load-buffer`, tmux will use the
+OSC52 escape sequence to directly set the clipboard for your terminal
+emulator--it should work even through an SSH session. Check out
 [A guide on how to copy text from anywhere][osc52] to read more about OSC52.
 
   [osc52]: https://old.reddit.com/r/vim/comments/k1ydpn/a_guide_on_how_to_copy_text_from_anywhere/

--- a/config.go
+++ b/config.go
@@ -89,7 +89,7 @@ type config struct {
 // Generates a new default configuration.
 func defaultConfig(cfg *config) *config {
 	return &config{
-		Action:   fmt.Sprintf("%v set-buffer -- {}", cfg.Tmux),
+		Action:   fmt.Sprintf("%v load-buffer -", cfg.Tmux),
 		Alphabet: _defaultAlphabet,
 		Regexes:  _defaultRegexes,
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -272,8 +272,8 @@ func TestConfigTmuxOptions(t *testing.T) {
 		},
 		{
 			desc: "action quoted",
-			give: `@fastcopy-action "tmux set-buffer -- {}"`,
-			want: config{Action: "tmux set-buffer -- {}"},
+			give: `@fastcopy-action "tmux load-buffer -"`,
+			want: config{Action: "tmux load-buffer -"},
 		},
 		{
 			desc: "alphabet",

--- a/main.go
+++ b/main.go
@@ -85,10 +85,10 @@ The following flags are available:
 	-action COMMAND
 		command and arguments that handle the selection.
 		The first '{}' in the argument list is the selected text.
-			-action 'tmux set-buffer -- {}'  # default
 		If there is no '{}', the selected text is sent over stdin.
+			-action 'tmux load-buffer -'  # default
 			-action pbcopy
-		Uses 'tmux set-buffer' by default.
+		Uses 'tmux load-buffer' by default.
 	-regex NAME:PATTERN
 		regular expressions to search for.
 		Name identifies the pattern. Add this option any number of


### PR DESCRIPTION
Passing the text to be copied to `set-buffer` has a theoretical
possibility of hitting the ARG_MAX limit. With `load-buffer`, we can
pass the text in over stdin and eliminate that risk.
