### PR TITLE
log/tail: Don't consume 100% CPU when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Don't consume 100% CPU when idling.
+
 ## 0.5.0 - 2021-09-07
 ### Changed
 - Change default action to `tmux load-buffer -`. This eliminates risk of

--- a/internal/tail/tail.go
+++ b/internal/tail/tail.go
@@ -85,9 +85,9 @@ func (t *Tee) run() {
 	defer ticker.Stop()
 
 	for {
-		_, err := io.CopyBuffer(t.W, t.R, t.buffer)
-		if err == nil {
-			// If the write succeded, copy the next chunk.
+		n, err := io.CopyBuffer(t.W, t.R, t.buffer)
+		if err == nil && n > 0 {
+			// There are more bytes still to read.
 			continue
 		}
 
@@ -96,9 +96,9 @@ func (t *Tee) run() {
 			// File is closed. No new logs are expected.
 			return
 
-		case errors.Is(err, io.EOF):
-			// Wait for quit or up to the specified delay and try
-			// again.
+		case err == nil || errors.Is(err, io.EOF):
+			// There were no more bytes left to copy. Wait for quit
+			// or up to the specified delay and try again.
 			select {
 			case <-t.quit:
 				return


### PR DESCRIPTION
The way log tailing was implemented, we were effectively spin looping
when the source had no bytes to produce but also had not yet hit EOF.

    while !eof {
        read(f)
    }

Fix this by spinning only if it had bytes to produce (indicating that
there may be more), and once it begins producing zero bytes, use the
same delay we would use for EOF.

    do {
        n = read(f)
    } while (n > 0 && !eof)

    if eof || n == 0 { sleep; retry }

This resolves 100% CPU usage when idling.

Fixes #38
