### PR TITLE
Test hint and annotation generation

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/abhinav/tmux-fastcopy/internal/fastcopy"
 	"github.com/abhinav/tmux-fastcopy/internal/log"
 	"github.com/abhinav/tmux-fastcopy/internal/tmux"
 	"github.com/abhinav/tmux-fastcopy/internal/ui"
@@ -142,7 +143,7 @@ type ctrl struct {
 	Text     string
 	Matcher  matcher
 
-	w   *Widget
+	w   *fastcopy.Widget
 	ui  *ui.App
 	sel string
 }
@@ -152,19 +153,19 @@ func (c *ctrl) Init() {
 		Background(tcell.ColorBlack).
 		Foreground(tcell.ColorWhite)
 
-	c.w = New(Config{
+	c.w = (&fastcopy.WidgetConfig{
 		Text:         c.Text,
 		Matches:      c.Matcher.Match(c.Text),
 		Handler:      c,
 		HintAlphabet: c.Alphabet,
-		Style: Style{
+		Style: fastcopy.Style{
 			Normal:         base,
 			Match:          base.Foreground(tcell.ColorGreen),
 			SkippedMatch:   base.Foreground(tcell.ColorGray),
 			HintLabel:      base.Foreground(tcell.ColorRed),
 			HintLabelInput: base.Foreground(tcell.ColorYellow),
 		},
-	})
+	}).Build()
 
 	c.ui = &ui.App{
 		Root:   c.w,

--- a/internal/envtest/env_test.go
+++ b/internal/envtest/env_test.go
@@ -1,0 +1,58 @@
+package envtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetenv(t *testing.T) {
+	t.Parallel()
+
+	env := MustPairs(
+		"FOO", "bar",
+		"BAZ", "",
+	)
+
+	t.Run("match", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "bar", env.Getenv("FOO"))
+	})
+
+	t.Run("empty match", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Empty(t, env.Getenv("BAZ"))
+	})
+
+	t.Run("empty no match", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Empty(t, env.Getenv("QUX"))
+	})
+}
+
+func TestGetenvNil(t *testing.T) {
+	t.Parallel()
+
+	var env *Env
+	assert.Empty(t, env.Getenv("QUX"))
+}
+
+func TestMustPairsOddArguments(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		MustPairs("foo", "bar", "baz")
+	})
+}
+
+func TestPairsOddArguments(t *testing.T) {
+	t.Parallel()
+
+	_, err := Pairs("foo", "bar", "baz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not even")
+}

--- a/internal/fastcopy/hint.go
+++ b/internal/fastcopy/hint.go
@@ -1,0 +1,111 @@
+package fastcopy
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/abhinav/tmux-fastcopy/internal/huffman"
+	"github.com/abhinav/tmux-fastcopy/internal/ui"
+)
+
+type hint struct {
+	Label   string
+	Text    string
+	Matches []Range
+}
+
+// generateHints generates a list of hints for the given text. It uses alphabet
+// to generate unique prefix-free labels for matche sin the text, where matches
+// are defined by the provided ranges.
+func generateHints(alphabet []rune, text string, matches []Range) []hint {
+	labelFrom := func(indexes []int) string {
+		label := make([]rune, len(indexes))
+		for i, idx := range indexes {
+			label[i] = alphabet[idx]
+		}
+		return string(label)
+	}
+
+	// Grouping of match ranges by their matched text.
+	byText := make(map[string][]Range)
+	for _, r := range matches {
+		match := text[r.Start:r.End]
+		byText[match] = append(byText[match], r)
+	}
+
+	uniqueMatches := make([]string, 0, len(byText))
+	for t := range byText {
+		uniqueMatches = append(uniqueMatches, t)
+	}
+	sort.Strings(uniqueMatches)
+
+	freqs := make([]int, len(uniqueMatches))
+	for i, t := range uniqueMatches {
+		freqs[i] = len(byText[t])
+	}
+
+	hints := make([]hint, len(uniqueMatches))
+	for i, labelIxes := range huffman.Label(len(alphabet), freqs) {
+		t := uniqueMatches[i]
+		hints[i] = hint{
+			Label:   labelFrom(labelIxes),
+			Text:    t,
+			Matches: byText[t],
+		}
+	}
+
+	return hints
+}
+func (h *hint) Annotations(input string, style Style) (anns []ui.TextAnnotation) {
+	matched := strings.HasPrefix(h.Label, input)
+
+	// If the hint matches the input, overlay the hint (both, typed
+	// and non-typed portions) over the string. Otherwise, grey out
+	// the match.
+	matchStyle := style.SkippedMatch
+	if matched {
+		matchStyle = style.Match
+	}
+
+	for _, pos := range h.Matches {
+		// Show the label only if there's no input, or if the input
+		// matches all or part of the label.
+		if matched {
+			i := 0
+
+			// Highlight the portion of the label already typed by
+			// the user.
+			if len(input) > 0 {
+				anns = append(anns, ui.OverlayTextAnnotation{
+					Offset:  pos.Start,
+					Overlay: input,
+					Style:   style.HintLabelInput,
+				})
+				i += len(input)
+			}
+
+			// Highlight the portion of the label yet to be typed.
+			if i < len(h.Label) {
+				anns = append(anns, ui.OverlayTextAnnotation{
+					Offset:  pos.Start + len(input),
+					Overlay: h.Label[i:],
+					Style:   style.HintLabel,
+				})
+			}
+
+			pos.Start += len(h.Label)
+		}
+
+		// Don't show the rest of the matched text if the label is
+		// longer than the text.
+		if pos.End > pos.Start {
+			anns = append(anns, ui.StyleTextAnnotation{
+				Offset: pos.Start,
+				Length: pos.End - pos.Start,
+				Style:  matchStyle,
+			})
+		}
+	}
+
+	return anns
+}

--- a/internal/fastcopy/hint_test.go
+++ b/internal/fastcopy/hint_test.go
@@ -1,0 +1,278 @@
+package fastcopy
+
+import (
+	"testing"
+
+	"github.com/abhinav/tmux-fastcopy/internal/ui"
+	tcell "github.com/gdamore/tcell/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateHints(t *testing.T) {
+	t.Parallel()
+
+	alphabet := []rune("abc")
+
+	tests := []struct {
+		desc    string
+		text    string
+		matches []Range
+		want    []hint
+	}{
+		{
+			desc: "no matches",
+			text: "foo",
+			want: []hint{},
+		},
+		{
+			desc: "single match",
+			text: "foo bar",
+			matches: []Range{
+				{1, 3}, // f(oo)
+			},
+			want: []hint{
+				{
+					Label: "a",
+					Text:  "oo",
+					Matches: []Range{
+						{1, 3}, // f(oo)
+					},
+				},
+			},
+		},
+		{
+			desc: "duplicated match",
+			text: "foo bar baz qux",
+			matches: []Range{
+				{4, 6},  // (ba)r
+				{8, 10}, // (ba)z
+			},
+			want: []hint{
+				{
+					Label: "a",
+					Text:  "ba",
+					Matches: []Range{
+						{4, 6},  // (ba)r
+						{8, 10}, // (ba)z
+					},
+				},
+			},
+		},
+		{
+			desc: "multiple matches",
+			text: "foo bar baz qux",
+			matches: []Range{
+				{0, 3},   // (foo)
+				{4, 6},   // (ba)r
+				{8, 10},  // (ba)z
+				{13, 15}, // q(ux)
+			},
+			want: []hint{
+				{
+					Label: "c",
+					Text:  "ba",
+					Matches: []Range{
+						{4, 6},  // (ba)r
+						{8, 10}, // (ba)z
+					},
+				},
+				{
+					Label: "a",
+					Text:  "foo",
+					Matches: []Range{
+						{0, 3}, // (foo)
+					},
+				},
+				{
+					Label: "b",
+					Text:  "ux",
+					Matches: []Range{
+						{13, 15}, // q(ux)
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := generateHints(alphabet, tt.text, tt.matches)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHintAnnotations(t *testing.T) {
+	t.Parallel()
+
+	style := Style{
+		Normal:         tcell.StyleDefault,
+		Match:          tcell.StyleDefault.Foreground(tcell.ColorGreen),
+		SkippedMatch:   tcell.StyleDefault.Foreground(tcell.ColorGray),
+		HintLabel:      tcell.StyleDefault.Foreground(tcell.ColorRed),
+		HintLabelInput: tcell.StyleDefault.Foreground(tcell.ColorYellow),
+	}
+
+	tests := []struct {
+		desc  string
+		give  hint
+		input string
+		want  []ui.TextAnnotation
+	}{
+		{
+			desc: "multiple matches",
+			give: hint{
+				Label: "a",
+				Text:  "foo",
+				Matches: []Range{
+					{0, 3},
+					{7, 10},
+				},
+			},
+			// [a]oo
+			want: []ui.TextAnnotation{
+				ui.OverlayTextAnnotation{
+					Offset:  0,
+					Overlay: "a",
+					Style:   style.HintLabel,
+				},
+				ui.StyleTextAnnotation{
+					Offset: 1,
+					Length: 2,
+					Style:  style.Match,
+				},
+				ui.OverlayTextAnnotation{
+					Offset:  7,
+					Overlay: "a",
+					Style:   style.HintLabel,
+				},
+				ui.StyleTextAnnotation{
+					Offset: 8,
+					Length: 2,
+					Style:  style.Match,
+				},
+			},
+		},
+		{
+			desc: "full input match",
+			give: hint{
+				Label: "a",
+				Text:  "foo",
+				Matches: []Range{
+					{0, 3},
+				},
+			},
+			input: "a",
+			want: []ui.TextAnnotation{
+				ui.OverlayTextAnnotation{
+					Offset:  0,
+					Overlay: "a",
+					Style:   style.HintLabelInput,
+				},
+				ui.StyleTextAnnotation{
+					Offset: 1,
+					Length: 2,
+					Style:  style.Match,
+				},
+			},
+		},
+		{
+			desc: "multi character label",
+			give: hint{
+				Label: "ab",
+				Text:  "foobar",
+				Matches: []Range{
+					{1, 7},
+				},
+			},
+			want: []ui.TextAnnotation{
+				ui.OverlayTextAnnotation{
+					Offset:  1,
+					Overlay: "ab",
+					Style:   style.HintLabel,
+				},
+				ui.StyleTextAnnotation{
+					Offset: 3,
+					Length: 4,
+					Style:  style.Match,
+				},
+			},
+		},
+		{
+			desc: "multi character label/input match",
+			give: hint{
+				Label: "ab",
+				Text:  "foobar",
+				Matches: []Range{
+					{1, 7},
+				},
+			},
+			input: "a",
+			want: []ui.TextAnnotation{
+				ui.OverlayTextAnnotation{
+					Offset:  1,
+					Overlay: "a",
+					Style:   style.HintLabelInput,
+				},
+				ui.OverlayTextAnnotation{
+					Offset:  2,
+					Overlay: "b",
+					Style:   style.HintLabel,
+				},
+				ui.StyleTextAnnotation{
+					Offset: 3,
+					Length: 4,
+					Style:  style.Match,
+				},
+			},
+		},
+		{
+			desc: "multi character label/input mismatch",
+			give: hint{
+				Label: "ab",
+				Text:  "foobar",
+				Matches: []Range{
+					{1, 7},
+				},
+			},
+			input: "x",
+			want: []ui.TextAnnotation{
+				ui.StyleTextAnnotation{
+					Offset: 1,
+					Length: 6,
+					Style:  style.SkippedMatch,
+				},
+			},
+		},
+		{
+			desc: "long label",
+			give: hint{
+				Label: "abcd",
+				Text:  "foo",
+				Matches: []Range{
+					{0, 3},
+				},
+			},
+			want: []ui.TextAnnotation{
+				ui.OverlayTextAnnotation{
+					Offset:  0,
+					Overlay: "abcd",
+					Style:   style.HintLabel,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.give.Annotations(tt.input, style)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/huffman/huffman_test.go
+++ b/internal/huffman/huffman_test.go
@@ -60,7 +60,17 @@ var (
 	}
 )
 
+func TestLabelAlphabetTooSmall(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		Label(1, []int{1, 2, 3})
+	})
+}
+
 func TestLabel(t *testing.T) {
+	t.Parallel()
+
 	type item struct {
 		Freq  int
 		Label string

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -95,11 +95,13 @@ func TestFormatting(t *testing.T) {
 	log.Debugf("level = %v", Debug)
 	log.Infof("level = %v", Info)
 	log.Errorf("level = %v", Error)
+	log.Errorf("level = %v", discard)
 
 	assert.Equal(t, unlines(
 		"level = debug",
 		"level = info",
 		"level = error",
+		"level = 2",
 	), buff.String())
 }
 

--- a/matcher.go
+++ b/matcher.go
@@ -4,18 +4,20 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+
+	"github.com/abhinav/tmux-fastcopy/internal/fastcopy"
 )
 
 type matcher []*regexpMatcher
 
-func (rms matcher) Match(s string) []Range {
+func (rms matcher) Match(s string) []fastcopy.Range {
 	var ms []match
 	for _, m := range rms {
 		ms = m.AppendMatches(s, ms)
 	}
 	ms = rms.removeOverlaps(ms)
 
-	rs := make([]Range, len(ms))
+	rs := make([]fastcopy.Range, len(ms))
 	for i, m := range ms {
 		rs[i] = m.Sel
 	}
@@ -94,10 +96,10 @@ func (rm *regexpMatcher) String() string {
 
 type match struct {
 	// Full matched area.
-	Full Range
+	Full fastcopy.Range
 
 	// Selected portion that will be copied.
-	Sel Range
+	Sel fastcopy.Range
 }
 
 func (rm *regexpMatcher) AppendMatches(s string, ms []match) []match {
@@ -106,8 +108,8 @@ func (rm *regexpMatcher) AppendMatches(s string, ms []match) []match {
 	}
 	for _, m := range rm.regex.FindAllStringSubmatchIndex(s, -1) {
 		ms = append(ms, match{
-			Full: Range{Start: m[0], End: m[1]},
-			Sel:  Range{Start: m[2*rm.subexp], End: m[2*rm.subexp+1]},
+			Full: fastcopy.Range{Start: m[0], End: m[1]},
+			Sel:  fastcopy.Range{Start: m[2*rm.subexp], End: m[2*rm.subexp+1]},
 		})
 	}
 	return ms


### PR DESCRIPTION
Move main.Widget and friends to an internal package and
test the hint/annotation generation logic separately.
Remove redundant empty annotations generated for hints.
Fill in minor pieces of missing coverage in
envtest, huffman, and log.
