### PR TITLE
tmux options: Handle single-quoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Better handle single-quoted strings in Tmux configuration.
+
 ## 0.6.1 - 2021-10-28
 ### Fixed
 - Homebrew formula: Conform to new Homebrew requirements.

--- a/internal/tmux/tmuxopt/tmuxopt_test.go
+++ b/internal/tmux/tmuxopt/tmuxopt_test.go
@@ -26,6 +26,14 @@ func TestLoaderStrings(t *testing.T) {
 			want: []string{},
 		},
 		{
+			desc: "empty value",
+			give: unlines(
+				"foo ",
+			),
+			options: []string{"foo"},
+			want:    []string{""},
+		},
+		{
 			desc: "simple values",
 			give: unlines(
 				"foo bar",
@@ -55,6 +63,14 @@ func TestLoaderStrings(t *testing.T) {
 			want:    []string{" "},
 		},
 		{
+			desc: "unquote/single quote/multiple characters",
+			give: unlines(
+				"prefix 'a b c'",
+			),
+			options: []string{"prefix"},
+			want:    []string{"a b c"},
+		},
+		{
 			desc: "unquote/double quote",
 			give: unlines(
 				`command "tmux set-buffer -- {}"`,
@@ -69,6 +85,29 @@ func TestLoaderStrings(t *testing.T) {
 			),
 			options: []string{"foo"},
 			want:    []string{`bar " baz`},
+		},
+		{
+			desc: "unquote/escape/single-quoted",
+			give: unlines(
+				`foo 'foo \\" bar'`,
+				// == set-option -g foo 'foo \" bar'
+			),
+			options: []string{"foo"},
+			want:    []string{`foo \" bar`},
+		},
+		{
+			// For
+			// https://github.com/abhinav/tmux-fastcopy/issues/48.
+			// Adding either of the following to your tmux.conf
+			// results in '"hello"' in the output.
+			//   set-option -g @fastcopy-regex-test1 "\"hello\""
+			//   set-option -g @fastcopy-regex-test1 '"hello"'
+			desc: "issue48",
+			give: unlines(
+				`@fastcopy-regex-test1 '"hello"'`,
+			),
+			options: []string{"@fastcopy-regex-test1"},
+			want:    []string{`"hello"`},
 		},
 	}
 


### PR DESCRIPTION
We use `strconv.Unquote` to unquote quoted strings from the Tmux
configuration.

However, this function only unquotes Go string literals.
Single-quoted strings are not valid string literals.

    strconv.Unquote(`'foo'`)
    // error: invalid syntax

Fix this by inverting the quotes on single-quoted strings, handing off
to strconv.Unquote, and inverting the result back.

Resolves #48
