### PR TITLE
Handle line wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Handle wrapping of long lines by Tmux.
+  These lines will now be joined when copied.
+
 ## 0.6.2 - 2021-12-29
 ### Fixed
 - Better handle single-quoted strings in Tmux configuration.

--- a/internal/tmux/shell.go
+++ b/internal/tmux/shell.go
@@ -134,7 +134,7 @@ func (s *ShellDriver) NewSession(req NewSessionRequest) ([]byte, error) {
 func (s *ShellDriver) CapturePane(req CapturePaneRequest) ([]byte, error) {
 	s.init()
 
-	args := []string{"capture-pane", "-p"}
+	args := []string{"capture-pane", "-p", "-J"}
 	if len(req.Pane) > 0 {
 		args = append(args, "-t", string(req.Pane))
 	}

--- a/internal/tmux/shell_test.go
+++ b/internal/tmux/shell_test.go
@@ -94,22 +94,22 @@ func TestCapturePaneArgs(t *testing.T) {
 	}{
 		{
 			desc: "empty",
-			want: []string{"capture-pane", "-p"},
+			want: []string{"capture-pane", "-p", "-J"},
 		},
 		{
 			desc: "pane",
 			give: CapturePaneRequest{Pane: "%42"},
-			want: []string{"capture-pane", "-p", "-t", "%42"},
+			want: []string{"capture-pane", "-p", "-J", "-t", "%42"},
 		},
 		{
 			desc: "start line",
 			give: CapturePaneRequest{StartLine: 42},
-			want: []string{"capture-pane", "-p", "-S", "42"},
+			want: []string{"capture-pane", "-p", "-J", "-S", "42"},
 		},
 		{
 			desc: "end line",
 			give: CapturePaneRequest{EndLine: 42},
-			want: []string{"capture-pane", "-p", "-E", "42"},
+			want: []string{"capture-pane", "-p", "-J", "-E", "42"},
 		},
 	}
 

--- a/internal/ui/text.go
+++ b/internal/ui/text.go
@@ -30,19 +30,19 @@ func DrawText(s string, style tcell.Style, view views.View, pos Pos) Pos {
 			combc = r[1:]
 		}
 
-		switch s := g.Str(); s {
-		case "\n":
+		s := g.Str()
+		if pos.X >= w || s == "\n" {
 			pos.Y++
 			pos.X = 0
-			if pos.Y >= h {
-				return pos
-			}
+		}
 
-		default:
-			if pos.X < w {
-				view.SetContent(pos.X, pos.Y, mainc, combc, style)
-				pos.X += runewidth.StringWidth(s)
-			}
+		if pos.Y >= h {
+			return pos
+		}
+
+		if s != "\n" {
+			view.SetContent(pos.X, pos.Y, mainc, combc, style)
+			pos.X += runewidth.StringWidth(s)
 		}
 	}
 

--- a/internal/ui/text_test.go
+++ b/internal/ui/text_test.go
@@ -41,7 +41,7 @@ func TestDrawText(t *testing.T) {
 			desc: "out of bounds/x",
 			w:    4,
 			text: "hello",
-			want: Pos{4, 0},
+			want: Pos{1, 1},
 		},
 		{
 			desc: "out of bounds/y",


### PR DESCRIPTION
When a line is longer than the width of the pane,
tmux wraps it like so:

    |foob|
    |ar  |

`tmux capture-pane` reports these as two separate lines by default.

    $ tmux capture-pane
    foob
    ar

This means that really long strings that would otherwise be matched by
tmux-fastcopy get split and possibly ignored.

We can address this by using the `-J` flag of `tmux capture-pane`,
which provides a more accurate representation of the actual text
on-screen.

    $ tmux capture-pane -J
    foobar

Combining that with some basic record-keeping of the screen width, we
can show the user the wrapped text, and still copy the actual unwrapped
text.

Testing this required making the integration test slightly more robust.

---

Before:
![before](https://user-images.githubusercontent.com/41730/153539102-9039a1d6-7ec2-4695-babf-43a96809ef30.gif)

After:
![after](https://user-images.githubusercontent.com/41730/153539126-1638bbea-9f9f-4aea-b490-03bf17f2eab4.gif)

