### PR TITLE
Pass regex names to action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Expose the name of the matched regex to the action with the
+  `FASTCOPY_REGEX_NAME` environment variable.
+
 ## 0.7.2 - 2022-02-19
 ### Added
 - For 32-bit ARM binaries, support ARM v5, v6, and v7.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,37 @@ If `{}` is absent from the command, tmux-fastcopy will pass the selected text
 to the command over stdin. For example,
 
     set-option -g @fastcopy-action pbcopy  # for macOS
+    
+#### Accessing the regex name
+    
+tmux-fastcopy executes the action with the `FASTCOPY_REGEX_NAME` environment
+variable set. This holds the [name of the regex](#regex-names) that matched the
+selected string.
+If multiple different regexes matched the string, `FASTCOPY_REGEX_NAME` holds a
+space-separated list of them.
+
+You can use this to customize the action on a per-regex basis.
+
+For example, the following will copy most strings to the tmux buffer as usual.
+However, if the string is matched by the "path" regular expression and it
+represents an existing directory, this will open that directory in the file
+browser.
+
+```bash
+#!/usr/bin/env bash
+
+# Place this inside a file like "fastcopy.sh",
+# mark it executable (chmod +x fastcopy.sh),
+# and set the @fastcopy-action setting to:
+#   '/path/to/fastcopy.sh {}'
+
+if [ "$FASTCOPY_REGEX_NAME" == path ] && [ -d "$1" ]; then
+    xdg-open "$1"  # on macOS, use "open" instead
+    exit 0
+fi
+
+tmux set-buffer -w "$1"
+```
 
 ### `@fastcopy-alphabet`
 
@@ -271,6 +302,10 @@ You can delete previously defined or default regular expressions by setting
 them to a blank string.
 
     set-option -g @fastcopy-regex-isodate ""
+
+The name of the regular expression that matched the selection is available to
+the [`@fastcopy-action`][] via the `FASTCOPY_REGEX_NAME` environment variable.
+See [Accessing the regex name](#accessing-the-regex-name) for more details.
 
 ## FAQ
 
@@ -360,6 +395,15 @@ value to delete it.
 For example, the following deletes the `isodate` regular expression.
 
     set-option -g @fastcopy-regex-isodate ""
+
+### Can I have different actions for different regexes?
+
+The `FASTCOPY_REGEX_NAME` environment variable holds the name of the regex that
+matched your selection.
+You can run different actions on a per-regex basis by inspecting the
+`FASTCOPY_REGEX_NAME` environment variable in your [`@fastcopy-action`][].
+
+See [Accessing the regex name](#accessing-the-regex-name) for more details.
 
 ## Credits
 

--- a/action_test.go
+++ b/action_test.go
@@ -82,14 +82,35 @@ func TestStdinAction(t *testing.T) {
 	var buff bytes.Buffer
 
 	action := stdinAction{
-		Cmd: "cat",
-		Log: log.New(&buff),
+		Cmd:     "cat",
+		Log:     log.New(&buff),
+		Environ: func() []string { return nil },
 	}
 	require.NoError(t, action.Run(fastcopy.Selection{
 		Text:     "foo",
 		Matchers: []string{"x"},
 	}))
 	assert.Equal(t, "[cat] foo\n", buff.String())
+}
+
+func TestStdinAction_RegexesEnv(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+
+	action := stdinAction{
+		Cmd: "env",
+		Log: log.New(&buff),
+		Environ: func() []string {
+			return []string{"FOO=bar"}
+		},
+	}
+	require.NoError(t, action.Run(fastcopy.Selection{
+		Text:     "foo",
+		Matchers: []string{"x", "y"},
+	}))
+	assert.Contains(t, buff.String(), "[env] FASTCOPY_REGEX_NAME=x y\n")
+	assert.Contains(t, buff.String(), "[env] FOO=bar\n")
 }
 
 func TestArgAction(t *testing.T) {
@@ -101,10 +122,31 @@ func TestArgAction(t *testing.T) {
 		BeforeArgs: []string{"1", "2"},
 		AfterArgs:  []string{"3", "4"},
 		Log:        log.New(&buff),
+		Environ:    func() []string { return nil },
 	}
 	require.NoError(t, action.Run(fastcopy.Selection{
 		Text:     "foo",
 		Matchers: []string{"x"},
 	}))
 	assert.Equal(t, "[echo] 1 2 foo 3 4\n", buff.String())
+}
+
+func TestArgAction_RegexesEnv(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	action := argAction{
+		Cmd:        "bash",
+		BeforeArgs: []string{"-c", "env"},
+		Log:        log.New(&buff),
+		Environ: func() []string {
+			return []string{"FOO=bar"}
+		},
+	}
+	require.NoError(t, action.Run(fastcopy.Selection{
+		Text:     "foo",
+		Matchers: []string{"x", "y"},
+	}))
+	assert.Contains(t, buff.String(), "[bash] FASTCOPY_REGEX_NAME=x y\n")
+	assert.Contains(t, buff.String(), "[bash] FOO=bar\n")
 }

--- a/action_test.go
+++ b/action_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/abhinav/tmux-fastcopy/internal/fastcopy"
 	"github.com/abhinav/tmux-fastcopy/internal/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,10 @@ func TestStdinAction(t *testing.T) {
 		Cmd: "cat",
 		Log: log.New(&buff),
 	}
-	require.NoError(t, action.Run("foo"))
+	require.NoError(t, action.Run(fastcopy.Selection{
+		Text:     "foo",
+		Matchers: []string{"x"},
+	}))
 	assert.Equal(t, "[cat] foo\n", buff.String())
 }
 
@@ -98,6 +102,9 @@ func TestArgAction(t *testing.T) {
 		AfterArgs:  []string{"3", "4"},
 		Log:        log.New(&buff),
 	}
-	require.NoError(t, action.Run("foo"))
+	require.NoError(t, action.Run(fastcopy.Selection{
+		Text:     "foo",
+		Matchers: []string{"x"},
+	}))
 	assert.Equal(t, "[echo] 1 2 foo 3 4\n", buff.String())
 }

--- a/app.go
+++ b/app.go
@@ -145,7 +145,7 @@ type ctrl struct {
 
 	w   *fastcopy.Widget
 	ui  *ui.App
-	sel string
+	sel fastcopy.Selection
 }
 
 func (c *ctrl) Init() {
@@ -176,12 +176,12 @@ func (c *ctrl) Init() {
 	c.ui.Start()
 }
 
-func (c *ctrl) Wait() (string, error) {
+func (c *ctrl) Wait() (fastcopy.Selection, error) {
 	err := c.ui.Wait()
 	return c.sel, err
 }
 
-func (c *ctrl) HandleSelection(_ string, text string) {
-	c.sel = text
+func (c *ctrl) HandleSelection(sel fastcopy.Selection) {
+	c.sel = sel
 	c.ui.Stop()
 }

--- a/internal/fastcopy/hint.go
+++ b/internal/fastcopy/hint.go
@@ -11,13 +11,13 @@ import (
 type hint struct {
 	Label   string
 	Text    string
-	Matches []Range
+	Matches []Match
 }
 
 // generateHints generates a list of hints for the given text. It uses alphabet
 // to generate unique prefix-free labels for matche sin the text, where matches
 // are defined by the provided ranges.
-func generateHints(alphabet []rune, text string, matches []Range) []hint {
+func generateHints(alphabet []rune, text string, matches []Match) []hint {
 	labelFrom := func(indexes []int) string {
 		label := make([]rune, len(indexes))
 		for i, idx := range indexes {
@@ -27,10 +27,11 @@ func generateHints(alphabet []rune, text string, matches []Range) []hint {
 	}
 
 	// Grouping of match ranges by their matched text.
-	byText := make(map[string][]Range)
-	for _, r := range matches {
+	byText := make(map[string][]Match)
+	for _, m := range matches {
+		r := m.Range
 		match := text[r.Start:r.End]
-		byText[match] = append(byText[match], r)
+		byText[match] = append(byText[match], m)
 	}
 
 	uniqueMatches := make([]string, 0, len(byText))
@@ -56,6 +57,7 @@ func generateHints(alphabet []rune, text string, matches []Range) []hint {
 
 	return hints
 }
+
 func (h *hint) Annotations(input string, style Style) (anns []ui.TextAnnotation) {
 	matched := strings.HasPrefix(h.Label, input)
 
@@ -67,7 +69,8 @@ func (h *hint) Annotations(input string, style Style) (anns []ui.TextAnnotation)
 		matchStyle = style.Match
 	}
 
-	for _, pos := range h.Matches {
+	for _, match := range h.Matches {
+		pos := match.Range
 		// Show the label only if there's no input, or if the input
 		// matches all or part of the label.
 		if matched {

--- a/internal/fastcopy/hint_test.go
+++ b/internal/fastcopy/hint_test.go
@@ -15,7 +15,7 @@ func TestGenerateHints(t *testing.T) {
 	tests := []struct {
 		desc    string
 		text    string
-		matches []Range
+		matches []Match
 		want    []hint
 	}{
 		{
@@ -26,15 +26,15 @@ func TestGenerateHints(t *testing.T) {
 		{
 			desc: "single match",
 			text: "foo bar",
-			matches: []Range{
-				{1, 3}, // f(oo)
+			matches: []Match{
+				{"name", Range{1, 3}}, // f(oo)
 			},
 			want: []hint{
 				{
 					Label: "a",
 					Text:  "oo",
-					Matches: []Range{
-						{1, 3}, // f(oo)
+					Matches: []Match{
+						{"name", Range{1, 3}}, // f(oo)
 					},
 				},
 			},
@@ -42,17 +42,17 @@ func TestGenerateHints(t *testing.T) {
 		{
 			desc: "duplicated match",
 			text: "foo bar baz qux",
-			matches: []Range{
-				{4, 6},  // (ba)r
-				{8, 10}, // (ba)z
+			matches: []Match{
+				{"name1", Range{4, 6}},  // (ba)r
+				{"name2", Range{8, 10}}, // (ba)z
 			},
 			want: []hint{
 				{
 					Label: "a",
 					Text:  "ba",
-					Matches: []Range{
-						{4, 6},  // (ba)r
-						{8, 10}, // (ba)z
+					Matches: []Match{
+						{"name1", Range{4, 6}},  // (ba)r
+						{"name2", Range{8, 10}}, // (ba)z
 					},
 				},
 			},
@@ -60,33 +60,33 @@ func TestGenerateHints(t *testing.T) {
 		{
 			desc: "multiple matches",
 			text: "foo bar baz qux",
-			matches: []Range{
-				{0, 3},   // (foo)
-				{4, 6},   // (ba)r
-				{8, 10},  // (ba)z
-				{13, 15}, // q(ux)
+			matches: []Match{
+				{"p", Range{0, 3}},   // (foo)
+				{"q", Range{4, 6}},   // (ba)r
+				{"r", Range{8, 10}},  // (ba)z
+				{"s", Range{13, 15}}, // q(ux)
 			},
 			want: []hint{
 				{
 					Label: "c",
 					Text:  "ba",
-					Matches: []Range{
-						{4, 6},  // (ba)r
-						{8, 10}, // (ba)z
+					Matches: []Match{
+						{"q", Range{4, 6}},  // (ba)r
+						{"r", Range{8, 10}}, // (ba)z
 					},
 				},
 				{
 					Label: "a",
 					Text:  "foo",
-					Matches: []Range{
-						{0, 3}, // (foo)
+					Matches: []Match{
+						{"p", Range{0, 3}}, // (foo)
 					},
 				},
 				{
 					Label: "b",
 					Text:  "ux",
-					Matches: []Range{
-						{13, 15}, // q(ux)
+					Matches: []Match{
+						{"s", Range{13, 15}}, // q(ux)
 					},
 				},
 			},
@@ -120,9 +120,9 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "a",
 				Text:  "foo",
-				Matches: []Range{
-					{0, 3},
-					{7, 10},
+				Matches: []Match{
+					{"x", Range{0, 3}},
+					{"y", Range{7, 10}},
 				},
 			},
 			// [a]oo
@@ -154,8 +154,8 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "a",
 				Text:  "foo",
-				Matches: []Range{
-					{0, 3},
+				Matches: []Match{
+					{"x", Range{0, 3}},
 				},
 			},
 			input: "a",
@@ -177,8 +177,8 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "ab",
 				Text:  "foobar",
-				Matches: []Range{
-					{1, 7},
+				Matches: []Match{
+					{"x", Range{1, 7}},
 				},
 			},
 			want: []ui.TextAnnotation{
@@ -199,8 +199,8 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "ab",
 				Text:  "foobar",
-				Matches: []Range{
-					{1, 7},
+				Matches: []Match{
+					{"x", Range{1, 7}},
 				},
 			},
 			input: "a",
@@ -227,8 +227,8 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "ab",
 				Text:  "foobar",
-				Matches: []Range{
-					{1, 7},
+				Matches: []Match{
+					{"x", Range{1, 7}},
 				},
 			},
 			input: "x",
@@ -245,8 +245,8 @@ func TestHintAnnotations(t *testing.T) {
 			give: hint{
 				Label: "abcd",
 				Text:  "foo",
-				Matches: []Range{
-					{0, 3},
+				Matches: []Match{
+					{"x", Range{0, 3}},
 				},
 			},
 			want: []ui.TextAnnotation{

--- a/internal/fastcopy/mock_handler_test.go
+++ b/internal/fastcopy/mock_handler_test.go
@@ -34,13 +34,13 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // HandleSelection mocks base method.
-func (m *MockHandler) HandleSelection(arg0, arg1 string) {
+func (m *MockHandler) HandleSelection(arg0 Selection) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HandleSelection", arg0, arg1)
+	m.ctrl.Call(m, "HandleSelection", arg0)
 }
 
 // HandleSelection indicates an expected call of HandleSelection.
-func (mr *MockHandlerMockRecorder) HandleSelection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) HandleSelection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSelection", reflect.TypeOf((*MockHandler)(nil).HandleSelection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSelection", reflect.TypeOf((*MockHandler)(nil).HandleSelection), arg0)
 }

--- a/internal/fastcopy/widget_test.go
+++ b/internal/fastcopy/widget_test.go
@@ -61,21 +61,21 @@ func TestWidget(t *testing.T) {
 	// 12 [(q u)x ] \n
 	w := (&WidgetConfig{
 		Text: "foo\nbar\nbaz\nqux",
-		Matches: []Range{
-			{0, 2},   // (fo)
-			{5, 7},   // (ar)
-			{9, 11},  // (az)
-			{12, 14}, // (qu)
+		Matches: []Match{
+			{"p", Range{0, 2}},   // (fo)
+			{"q", Range{5, 7}},   // (ar)
+			{"r", Range{9, 11}},  // (az)
+			{"s", Range{12, 14}}, // (qu)
 		},
 		HintAlphabet: []rune("ab"),
 		Handler:      handler,
 		Style:        style,
-		generateHints: func([]rune, string, []Range) []hint {
+		generateHints: func([]rune, string, []Match) []hint {
 			return []hint{
-				{Label: "aa", Text: "fo", Matches: []Range{{0, 2}}},   // (fo)
-				{Label: "bb", Text: "ar", Matches: []Range{{5, 7}}},   // (ar)
-				{Label: "ba", Text: "az", Matches: []Range{{9, 11}}},  // (az)
-				{Label: "ab", Text: "qu", Matches: []Range{{12, 14}}}, // (qu)
+				{Label: "aa", Text: "fo", Matches: []Match{{"p", Range{0, 2}}}},   // (fo)
+				{Label: "bb", Text: "ar", Matches: []Match{{"q", Range{5, 7}}}},   // (ar)
+				{Label: "ba", Text: "az", Matches: []Match{{"r", Range{9, 11}}}},  // (az)
+				{Label: "ab", Text: "qu", Matches: []Match{{"p", Range{12, 14}}}}, // (qu)
 			}
 		},
 	}).Build()
@@ -107,7 +107,7 @@ func TestWidget(t *testing.T) {
 
 	t.Run("select", func(t *testing.T) {
 		handler.EXPECT().
-			HandleSelection("ba", "az")
+			HandleSelection(Selection{Text: "az", Matchers: []string{"r"}})
 
 		assert.True(t,
 			w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'b', 0)))

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 		Stderr:     os.Stderr,
 		Executable: os.Executable,
 		Getenv:     os.Getenv,
+		Environ:    os.Environ,
 		Getpid:     os.Getpid,
 	}
 
@@ -62,6 +63,7 @@ type mainCmd struct {
 
 	Executable func() (string, error) // == os.Executable
 	Getenv     func(string) string    // == os.Getenv
+	Environ    func() []string        // == os.Environ
 	Getpid     func() int
 
 	newTmuxDriver func(string) tmuxShellDriver
@@ -167,7 +169,8 @@ func (cmd *mainCmd) Run(cfg *config) (err error) {
 			Tmux:      tmuxDriver,
 			NewScreen: tcell.NewScreen,
 			NewAction: (&actionFactory{
-				Log: logger,
+				Log:     logger,
+				Environ: cmd.Environ,
 			}).New,
 		}
 	} else {


### PR DESCRIPTION
Pass the name of the matched regular expression to the action via the `FASTCOPY_REGEX_NAME` environment variable.

If multiple regular expressions matched the text, the environment variable holds a space-separated list rather than a singular value.

Refs #56 