### PR TITLE
Support fastcopy-shift-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add `@fastcopy-shift-action` to specify an alternative action to be run when
+  a label is selected with the Shift key pressed.
+
 ## 0.8.0 - 2022-04-01
 ### Added
 - Expose the name of the matched regex to the action with the

--- a/README.md
+++ b/README.md
@@ -152,11 +152,13 @@ Use the following tmux options to configure the behavior of tmux-fastcopy.
 
 - [`@fastcopy-key`][] invokes tmux-fastcopy with the tmux prefix
 - [`@fastcopy-action`][] copies the selected text
+- [`@fastcopy-shift-action`][] specifies an alternative action
 - [`@fastcopy-alphabet`][] specifies the letters used to generate labels
 - [`@fastcopy-regex-*`][] specify the regular expressions for matching text
 
   [`@fastcopy-key`]: #fastcopy-key
   [`@fastcopy-action`]: #fastcopy-action
+  [`@fastcopy-shift-action`]: #fastcopy-shift-action
   [`@fastcopy-alphabet`]: #fastcopy-alphabet
   [`@fastcopy-regex-*`]: #fastcopy-regex-
 
@@ -187,9 +189,9 @@ If `{}` is absent from the command, tmux-fastcopy will pass the selected text
 to the command over stdin. For example,
 
     set-option -g @fastcopy-action pbcopy  # for macOS
-    
+
 #### Accessing the regex name
-    
+
 tmux-fastcopy executes the action with the `FASTCOPY_REGEX_NAME` environment
 variable set. This holds the [name of the regex](#regex-names) that matched the
 selected string.
@@ -218,6 +220,26 @@ fi
 
 tmux set-buffer -w "$1"
 ```
+
+### `@fastcopy-shift-action`
+
+An alternative action when you select a label while pressing shift.
+Nothing happens if this is unset.
+
+**Default**:
+
+    set-option -g @fastcopy-shift-action ''
+
+Similarly to [`@fastcopy-action`], the string specifies a command and its
+arguments, and the special argument `{}` (if any) is a placeholder for the
+selected text.
+
+    set-option -g @fastcopy-shift-action "fastcopy-shift.sh {}"
+
+As with `@fastcopy-action`, tmux-fastcopy will set `FASTCOPY_REGEX_NAME` to the
+name of the regular expression that matched when running the
+`@fastcopy-shift-action`.
+See [Accessing the regex name](#accessing-the-regex-name) for more details.
 
 ### `@fastcopy-alphabet`
 
@@ -279,7 +301,7 @@ This also means that to use `(...)` in regular expressions that should copy the
 whole string, you should add the `?:` prefix to the start of the capturing
 group to ignore it. For example,
 
-    # Matches commands suggested by 'git status' 
+    # Matches commands suggested by 'git status'
     set-option -g @fastcopy-regex-git-rebase "git rebase --(?:continue|abort)"
 
 #### Regex names

--- a/app.go
+++ b/app.go
@@ -128,9 +128,18 @@ func (app *app) Run(cfg *config) error {
 		return err
 	}
 
-	action, err := app.NewAction(cfg.Action)
+	actionStr := cfg.Action
+	if selection.Shift {
+		actionStr = cfg.ShiftAction
+	}
+
+	if len(actionStr) == 0 {
+		return nil
+	}
+
+	action, err := app.NewAction(actionStr)
 	if err != nil {
-		return fmt.Errorf("load action %q: %v", cfg.Action, err)
+		return fmt.Errorf("load action %q: %v", actionStr, err)
 	}
 
 	return action.Run(selection)

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/abhinav/tmux-fastcopy/internal/log/logtest"
+	"github.com/abhinav/tmux-fastcopy/internal/tmux/tmuxtest"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApp_Run_badRegex(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	err := (&app{
+		Log:  logtest.NewLogger(t),
+		Tmux: tmuxtest.NewMockDriver(mockCtrl),
+	}).Run(&config{
+		Regexes: regexes{
+			"foo": "not(a{valid[regex",
+		},
+	})
+	require.Error(t, err, "run must fail")
+	assert.ErrorContains(t, err, `compile regex "foo"`)
+}
+
+func TestApp_Run_inspectPaneError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	tmuxDriver := tmuxtest.NewMockDriver(mockCtrl)
+	tmuxDriver.EXPECT().
+		DisplayMessage(tmuxtest.DisplayMessageRequestMatcher{Pane: "42"}).
+		Return(nil, errors.New("great sadness"))
+
+	err := (&app{
+		Log:  logtest.NewLogger(t),
+		Tmux: tmuxDriver,
+	}).Run(&config{Pane: "42"})
+	require.Error(t, err, "run must fail")
+	assert.ErrorContains(t, err, "great sadness")
+}

--- a/config.go
+++ b/config.go
@@ -77,13 +77,14 @@ func (m *regexes) FillFrom(o regexes) {
 }
 
 type config struct {
-	Pane     string
-	Action   string
-	Alphabet alphabet
-	Verbose  bool
-	Regexes  regexes
-	Tmux     string
-	LogFile  string
+	Pane        string
+	Action      string
+	ShiftAction string
+	Alphabet    alphabet
+	Verbose     bool
+	Regexes     regexes
+	Tmux        string
+	LogFile     string
 }
 
 // Generates a new default configuration.
@@ -99,6 +100,7 @@ func (c *config) RegisterFlags(flag *flag.FlagSet) {
 	// No help here because we put it all in _usage.
 	flag.StringVar(&c.Pane, "pane", "", "")
 	flag.StringVar(&c.Action, "action", "", "")
+	flag.StringVar(&c.ShiftAction, "shift-action", "", "")
 	flag.Var(&c.Alphabet, "alphabet", "")
 	flag.Var(&c.Regexes, "regex", "")
 	flag.BoolVar(&c.Verbose, "verbose", false, "")
@@ -108,6 +110,7 @@ func (c *config) RegisterFlags(flag *flag.FlagSet) {
 
 func (c *config) RegisterOptions(load *tmuxopt.Loader) {
 	load.StringVar(&c.Action, "@fastcopy-action")
+	load.StringVar(&c.ShiftAction, "@fastcopy-shift-action")
 	load.Var(&c.Alphabet, "@fastcopy-alphabet")
 	load.MapVar(&c.Regexes, "@fastcopy-regex-")
 }
@@ -120,6 +123,9 @@ func (c *config) FillFrom(o *config) {
 	}
 	if len(c.Action) == 0 {
 		c.Action = o.Action
+	}
+	if len(c.ShiftAction) == 0 {
+		c.ShiftAction = o.ShiftAction
 	}
 	if len(c.Alphabet) == 0 {
 		c.Alphabet = o.Alphabet
@@ -143,6 +149,9 @@ func (c *config) Flags() []string {
 	}
 	if len(c.Action) > 0 {
 		args = append(args, "-action", c.Action)
+	}
+	if len(c.ShiftAction) > 0 {
+		args = append(args, "-shift-action", c.ShiftAction)
 	}
 	if len(c.Alphabet) > 0 {
 		args = append(args, "-alphabet", c.Alphabet.String())

--- a/config_test.go
+++ b/config_test.go
@@ -160,6 +160,7 @@ func TestConfigDefaults(t *testing.T) {
 	cfg.FillFrom(defaultConfig(&cfg))
 
 	assert.Equal(t, "tmux load-buffer -", cfg.Action)
+	assert.Empty(t, cfg.ShiftAction)
 	assert.Equal(t, _defaultAlphabet, cfg.Alphabet)
 
 	for k, v := range _defaultRegexes {
@@ -195,6 +196,11 @@ func TestConfigFlags(t *testing.T) {
 			desc: "action",
 			give: []string{"-action", "pbcopy"},
 			want: config{Action: "pbcopy", Tmux: "tmux"},
+		},
+		{
+			desc: "shift action",
+			give: []string{"-shift-action", "open"},
+			want: config{ShiftAction: "open", Tmux: "tmux"},
 		},
 		{
 			desc: "alphabet",
@@ -320,6 +326,11 @@ func TestConfigTmuxOptions(t *testing.T) {
 			want: config{Action: "tmux load-buffer -"},
 		},
 		{
+			desc: "shift-action",
+			give: "@fastcopy-shift-action open",
+			want: config{ShiftAction: "open"},
+		},
+		{
 			desc: "alphabet",
 			give: "@fastcopy-alphabet abc",
 			want: config{Alphabet: "abc"},
@@ -389,11 +400,12 @@ func TestConfigMerge(t *testing.T) {
 					},
 				},
 				{
-					Pane:     "ignored",
-					Action:   "ignored",
-					Alphabet: "ignored",
-					LogFile:  "ignored.txt",
-					Tmux:     "/usr/bin/tmux",
+					Pane:        "ignored",
+					Action:      "ignored",
+					ShiftAction: "open",
+					Alphabet:    "ignored",
+					LogFile:     "ignored.txt",
+					Tmux:        "/usr/bin/tmux",
 					Regexes: regexes{
 						"foo": "ignored",
 						"bar": "baz",
@@ -401,12 +413,13 @@ func TestConfigMerge(t *testing.T) {
 				},
 			},
 			want: config{
-				Pane:     "foo",
-				Action:   "bar",
-				Alphabet: "abc",
-				Verbose:  true,
-				LogFile:  "foo.txt",
-				Tmux:     "/usr/bin/tmux",
+				Pane:        "foo",
+				Action:      "bar",
+				ShiftAction: "open",
+				Alphabet:    "abc",
+				Verbose:     true,
+				LogFile:     "foo.txt",
+				Tmux:        "/usr/bin/tmux",
 				Regexes: regexes{
 					"foo": "bar",
 					"bar": "baz",
@@ -426,12 +439,14 @@ func TestConfigMerge(t *testing.T) {
 				{Regexes: regexes{"bar": "ignored"}},
 				{LogFile: "foo.txt"},
 				{Tmux: "/usr/local/bin/tmux"},
+				{ShiftAction: "open"},
 			},
 			want: config{
-				Pane:     "foo",
-				Action:   "bar",
-				Alphabet: "abc",
-				Verbose:  true,
+				Pane:        "foo",
+				Action:      "bar",
+				ShiftAction: "open",
+				Alphabet:    "abc",
+				Verbose:     true,
 				Regexes: regexes{
 					"foo": "bar",
 					"bar": "baz",
@@ -514,7 +529,6 @@ func TestUsageHasAllConfigFlags(t *testing.T) {
 		assert.Contains(t, _usage, "\t-"+f.Name,
 			"flag %q should be documented", f.Name)
 	})
-
 }
 
 var (
@@ -524,13 +538,14 @@ var (
 
 func generateConfig(t testing.TB, rand *rand.Rand) config {
 	return config{
-		Pane:     generateString(t, rand, 0, "generate pane"),
-		Action:   generateString(t, rand, 0, "generate action"),
-		Alphabet: generateAlphabet(t, rand),
-		Verbose:  generateValue(t, rand, _typeBool, "verbose").(bool),
-		Regexes:  generateRegexes(t, rand),
-		LogFile:  generateString(t, rand, 0, "generate logFile"),
-		Tmux:     generateString(t, rand, 1, "generate tmux"),
+		Pane:        generateString(t, rand, 0, "generate pane"),
+		Action:      generateString(t, rand, 0, "generate action"),
+		ShiftAction: generateString(t, rand, 0, "generate shift action"),
+		Alphabet:    generateAlphabet(t, rand),
+		Verbose:     generateValue(t, rand, _typeBool, "verbose").(bool),
+		Regexes:     generateRegexes(t, rand),
+		LogFile:     generateString(t, rand, 0, "generate logFile"),
+		Tmux:        generateString(t, rand, 1, "generate tmux"),
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -160,15 +160,15 @@ var _wantMatches = []matchInfo{
 
 func TestIntegration_SelectMatches(t *testing.T) {
 	t.Run("default action", func(t *testing.T) {
-		testIntegration_SelectMatches(t, false)
+		testIntegrationSelectMatches(t, false)
 	})
 
 	t.Run("shift action", func(t *testing.T) {
-		testIntegration_SelectMatches(t, true)
+		testIntegrationSelectMatches(t, true)
 	})
 }
 
-func testIntegration_SelectMatches(t *testing.T, shift bool) {
+func testIntegrationSelectMatches(t *testing.T, shift bool) {
 	var envConfig fakeEnvConfig
 	if shift {
 		envConfig.Action = "unexpected"

--- a/internal/fastcopy/widget_test.go
+++ b/internal/fastcopy/widget_test.go
@@ -114,4 +114,18 @@ func TestWidget(t *testing.T) {
 		assert.True(t,
 			w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'a', 0)))
 	})
+
+	t.Run("shift select", func(t *testing.T) {
+		handler.EXPECT().
+			HandleSelection(Selection{
+				Text:     "qu",
+				Matchers: []string{"p"},
+				Shift:    true,
+			})
+
+		assert.True(t,
+			w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'a', 0)))
+		assert.True(t,
+			w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'B', 0)))
+	})
 }

--- a/internal/tmux/tmuxtest/matchers.go
+++ b/internal/tmux/tmuxtest/matchers.go
@@ -1,0 +1,27 @@
+package tmuxtest
+
+import (
+	"fmt"
+
+	"github.com/abhinav/tmux-fastcopy/internal/tmux"
+	"github.com/golang/mock/gomock"
+)
+
+type DisplayMessageRequestMatcher struct {
+	Pane string
+}
+
+var _ gomock.Matcher = DisplayMessageRequestMatcher{}
+
+func (m DisplayMessageRequestMatcher) String() string {
+	return fmt.Sprintf("DisplayMessageRequest{Pane: %q}", m.Pane)
+}
+
+func (m DisplayMessageRequestMatcher) Matches(x interface{}) bool {
+	req, ok := x.(tmux.DisplayMessageRequest)
+	if !ok {
+		return false
+	}
+
+	return req.Pane == m.Pane
+}

--- a/internal/tmux/tmuxtest/matchers.go
+++ b/internal/tmux/tmuxtest/matchers.go
@@ -7,6 +7,8 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+// DisplayMessageRequestMatcher is a gomock matcher that matches
+// tmux.DisplayMessageRequest objects by pane ID.
 type DisplayMessageRequestMatcher struct {
 	Pane string
 }
@@ -17,6 +19,7 @@ func (m DisplayMessageRequestMatcher) String() string {
 	return fmt.Sprintf("DisplayMessageRequest{Pane: %q}", m.Pane)
 }
 
+// Matches reports whether the provided DisplayMessageRequest matches.
 func (m DisplayMessageRequestMatcher) Matches(x interface{}) bool {
 	req, ok := x.(tmux.DisplayMessageRequest)
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -85,12 +85,16 @@ The following flags are available:
 		pane identifier.
 		Uses the current pane if unspecified.
 	-action COMMAND
+	-shift-action COMMAND
 		command and arguments that handle the selection.
+		'action' specifies the default selection action, and
+		'shift-action' specifies the action with the Shift key pressed.
 		The first '{}' in the argument list is the selected text.
 		If there is no '{}', the selected text is sent over stdin.
 			-action 'tmux load-buffer -'  # default
-			-action pbcopy
-		Uses 'tmux load-buffer' by default.
+			-action pbcopy -shift-action open
+		Uses 'tmux load-buffer' by default for 'action' and no-op for
+		'shift-action'.
 	-regex NAME:PATTERN
 		regular expressions to search for.
 		Name identifies the pattern. Add this option any number of
@@ -101,6 +105,8 @@ The following flags are available:
 		Capture groups in the regex indicate the text to be copied,
 		defaulting to the whole string if there are no capture groups.
 			-regex 'gitsha:([0-9a-f]{7})[0-9a-f]{,33}'
+		Actions receive the name of the matching regex in the
+		FASTCOPY_REGEX_NAME environment variable.
 		Default set includes: ipv4, gitsha, hexaddr, hexcolor, int,
 		path, uuid.
 	-alphabet STRING


### PR DESCRIPTION
Add support for specifying an alternative action if the Shift key is
pressed at the time the label is selected.

By default, this new option is a no-op.

Resolves #56
