### PR TITLE
ci/release: Fix release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
         set -eou pipefail
         VERSION=${{ github.ref }}
         VERSION="${VERSION#refs/tags/}"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
         echo "Releasing $VERSION"
         echo "Release notes:"
         echo "----"
-        parse-changelog CHANGELOG.md "${VERSION#v}" | tee changes.$VERSION.txt
+        parse-changelog CHANGELOG.md "${VERSION#v}" | tee "changes.$VERSION.txt"
         echo "----"
 
     - name: Release
@@ -45,7 +45,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: release --rm-dist --release-notes changes.${{ env.VERSION }}.txt
+        args: release --clean --release-notes changes.${{ env.VERSION }}.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AUR_KEY: ${{ secrets.AUR_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,3 @@ checksum:
 
 snapshot:
   name_template: "{{ incminor .Tag }}-dev"
-
-changelog:
-  # A commit log is not a changelog.
-  skip: true


### PR DESCRIPTION
goreleaser does not update release notes
if changelog.skip is true
even if --release-notes is passed.
Drop it to resolve the issue.

Related: abhinav/stitchmd#54
Related: abhinav/stitchmd#53
Related: abhinav/doc2go#87
