### PR TITLE
Attempt -test.gocoverdir workaround

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.x
+        cache: true
+    - name: Download and install dependencies
+      run: |
+        go mod download
+    - name: Lint
+      run: make lint
 
   build:
     runs-on: ubuntu-latest
@@ -19,7 +34,6 @@ jobs:
     name: Test / Tmux ${{ matrix.tmux-version }}
 
     steps:
-
     - uses: actions/checkout@v3
 
     - name: Checkout Tmux
@@ -60,13 +74,8 @@ jobs:
     - name: Build tmux-fastcopy
       run: make build
 
-    - name: Lint
-      run: make lint
-
     - name: Test
       run: PATH="$HOME/.local/bin:$PATH" make cover
 
     - name: Coverage
       uses: codecov/codecov-action@v3
-      with:
-        files: ./cover.out,./cover.integration.out

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,12 @@ cover: $(GO_FILES)
 	$(eval BIN := $(shell mktemp -d))
 	$(eval COVERDIR := $(shell mktemp -d))
 	GOBIN=$(BIN) \
-	      go install -cover -coverpkg=./... github.com/abhinav/tmux-fastcopy
+		go install -race -cover -coverpkg=./... github.com/abhinav/tmux-fastcopy
+	go test -cover -race -coverpkg=./... \
+		-c -o $(BIN)/tmux-fastcopy.test
 	GOCOVERDIR=$(COVERDIR) PATH=$(BIN):$$PATH \
-		   go test -v -race -coverprofile=cover.out -coverpkg=./... ./...
-	go tool covdata textfmt -i=$(COVERDIR) -o=cover.integration.out
+		$(BIN)/tmux-fastcopy.test -test.v -test.gocoverdir=$(COVERDIR) ./...
+	go tool covdata textfmt -i=$(COVERDIR) -o=cover.out
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: lint


### PR DESCRIPTION
Instead of generating two separate coverage profiles,
generate one by having the test binary write coverage data
with the -test.gocoverdir flag.
