### PR TITLE
ui: Don't use a render loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Use event-based rendering instead of fixed rate rendering.
+  This should reduce flickering on slow systems.
+
 ## 0.9.0 - 2022-05-29
 ### Added
 - Add `@fastcopy-shift-action` to specify an alternative action to be run when

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3,53 +3,20 @@ package ui
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/abhinav/tmux-fastcopy/internal/log"
 	"github.com/abhinav/tmux-fastcopy/internal/log/logtest"
-	"github.com/benbjohnson/clock"
 	tcell "github.com/gdamore/tcell/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAppRender(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	scr := NewTestScreen(t, 80, 40)
-	clock := clock.NewMock()
-	widget := NewMockWidget(ctrl)
-
-	app := App{
-		Root:   widget,
-		Screen: scr,
-		Clock:  clock,
-		Log:    logtest.NewLogger(t),
-		FPS:    1, // keep the math for time below simple
-	}
-	app.Start()
-	defer func() {
-		app.Stop()
-		assert.NoError(t, app.Wait())
-	}()
-
-	// There's a small race condition here, and since we don't have any
-	// hook into things actually getting drawn onto the screen, make it a
-	// bit fuzzy: leave some slack.
-	widget.EXPECT().Draw(gomock.Any()).MinTimes(90).MaxTimes(100)
-	for i := 0; i < 100; i++ {
-		clock.Add(time.Second)
-	}
-}
-
 func TestAppEvents(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	scr := NewTestScreen(t, 80, 40)
-	clock := clock.NewMock()
 
 	widget := NewMockWidget(ctrl)
 	widget.EXPECT().Draw(gomock.Any()).AnyTimes()
@@ -57,7 +24,6 @@ func TestAppEvents(t *testing.T) {
 	app := App{
 		Root:   widget,
 		Screen: scr,
-		Clock:  clock,
 		Log:    logtest.NewLogger(t),
 	}
 	app.Start()


### PR DESCRIPTION
Rendering at 25 FPS causes occasional flickering
on some of the lower end machines.

This fixed rate of rendering isn't necessary
since tmux-fastcopy's UI widget is quite simple.

Switch to event-based rendering:
render after processing each event.
The rate at which we receive events is quite low,
so this shouldn't be an issue.
