### PR TITLE
goreleaser: archive.replacements is deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,12 +27,13 @@ builds:
     ldflags: '-s -w -X main._version={{.Version}}'
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
 aurs:
   - name: tmux-fastcopy-bin


### PR DESCRIPTION
(Ab)use name_template to achieve the same pattern
to avoid breaking existing users and scripts.