### PR TITLE
ci(lint): tparallel => paralleltest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,11 +32,11 @@ linters:
     - noctx
     - nolintlint
     - nosprintfhostport
+    - paralleltest
     - reassign
     - revive
     - rowserrcheck
     - tenv
-    - tparallel
     - unconvert
     - whitespace
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -216,6 +216,8 @@ func testIntegrationSelectMatches(t *testing.T, shift bool) {
 }
 
 func TestIntegration_ShiftNoop(t *testing.T) {
+	t.Parallel()
+
 	env := (&fakeEnvConfig{
 		Action: "unexpected",
 	}).Build(t)

--- a/internal/fastcopy/widget_test.go
+++ b/internal/fastcopy/widget_test.go
@@ -47,7 +47,7 @@ func sampleStyle() Style {
 	}
 }
 
-//nolint:tparallel // shared state between subtests
+//nolint:paralleltest // shared state between subtests
 func TestWidget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tail/tail_test.go
+++ b/internal/tail/tail_test.go
@@ -38,7 +38,7 @@ func (b *lockedBuffer) String() string {
 	return b.buff.String()
 }
 
-//nolint:tparallel // shared state between subtests
+//nolint:paralleltest // shared state between subtests
 func TestTee(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/annotated_text_test.go
+++ b/internal/ui/annotated_text_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:tparallel // shared state between subtests
+//nolint:paralleltest // shared state between subtests
 func TestAnnotatedText(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:tparallel // shared state between subtests
+//nolint:paralleltest // shared state between subtests
 func TestAppEvents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This verifies that all tests use t.Parallel,
versus just verifying correct usage of t.Parallel.
