### PR TITLE
action: Run inside pane directory

### DIFF
--- a/.changes/unreleased/Changed-20230611-122531.yaml
+++ b/.changes/unreleased/Changed-20230611-122531.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: Run `fastcopy-action` and `fastcopy-shift-action` inside the pane's current
+  directory, if available.
+time: 2023-06-11T12:25:31.129359475-07:00

--- a/README.md
+++ b/README.md
@@ -216,11 +216,17 @@ to the command over stdin. For example,
 set-option -g @fastcopy-action pbcopy  # for macOS
 ```
 
-Note that the command string is executed through the tmux-fastcopy binary,
-so it must be a path to a binary or shell script that is executable,
-and is not executed in the context of a full login shell.
-Additionally, if the command string uses `{}`,
+Note that if the command string uses `{}`,
 the selected text is *not* passed via stdin.
+
+#### Execution context
+
+The command string is executed directly by tmux-fastcopy,
+so it must be a path to a binary or shell script that is executable.
+It is not executed in the context of a full login shell.
+
+The command runs inside the directory of the pane
+where tmux-fastcopy was invoked if this information is available from tmux.
 
 ### `@fastcopy-shift-action`
 

--- a/app.go
+++ b/app.go
@@ -16,7 +16,7 @@ import (
 type app struct {
 	Log       *log.Logger
 	Tmux      tmux.Driver
-	NewAction func(string) (action, error)
+	NewAction func(newActionRequest) (action, error)
 
 	NewScreen func() (tcell.Screen, error) // == tcell.NewScreen
 }
@@ -141,7 +141,10 @@ func (app *app) Run(cfg *config) error {
 		return nil
 	}
 
-	action, err := app.NewAction(actionStr)
+	action, err := app.NewAction(newActionRequest{
+		Action: actionStr,
+		Dir:    targetPane.CurrentPath,
+	})
 	if err != nil {
 		return fmt.Errorf("load action %q: %v", actionStr, err)
 	}

--- a/doc/opt-action.md
+++ b/doc/opt-action.md
@@ -17,8 +17,14 @@ to the command over stdin. For example,
 
     set-option -g @fastcopy-action pbcopy  # for macOS
 
-Note that the command string is executed through the tmux-fastcopy binary,
-so it must be a path to a binary or shell script that is executable,
-and is not executed in the context of a full login shell.
-Additionally, if the command string uses `{}`,
+Note that if the command string uses `{}`,
 the selected text is *not* passed via stdin.
+
+## Execution context
+
+The command string is executed directly by tmux-fastcopy,
+so it must be a path to a binary or shell script that is executable.
+It is not executed in the context of a full login shell.
+
+The command runs inside the directory of the pane
+where tmux-fastcopy was invoked if this information is available from tmux.

--- a/internal/tmux/inspect.go
+++ b/internal/tmux/inspect.go
@@ -26,6 +26,9 @@ type PaneInfo struct {
 	Mode           PaneMode
 	ScrollPosition int
 	WindowZoomed   bool
+
+	// Current path of the pane, if available.
+	CurrentPath string
 }
 
 func (i *PaneInfo) String() string {
@@ -36,14 +39,16 @@ func (i *PaneInfo) String() string {
 	b.Put("height", i.Height)
 	b.Put("mode", i.Mode)
 	b.Put("scrollPosition", i.ScrollPosition)
+	b.Put("currentPath", i.CurrentPath)
 	return b.String()
 }
 
 var (
-	_paneID     = tmuxfmt.Var("pane_id")
-	_paneWidth  = tmuxfmt.Var("pane_width")
-	_paneHeight = tmuxfmt.Var("pane_height")
-	_paneMode   = tmuxfmt.Ternary{
+	_paneCurrentPath = tmuxfmt.Var("pane_current_path")
+	_paneID          = tmuxfmt.Var("pane_id")
+	_paneWidth       = tmuxfmt.Var("pane_width")
+	_paneHeight      = tmuxfmt.Var("pane_height")
+	_paneMode        = tmuxfmt.Ternary{
 		Cond: tmuxfmt.Var("pane_in_mode"),
 		Then: tmuxfmt.Var("pane_mode"),
 		Else: tmuxfmt.String("normal-mode"),
@@ -77,6 +82,7 @@ func InspectPane(driver Driver, identifier string) (*PaneInfo, error) {
 	fc.StringVar((*string)(&info.Mode), _paneMode)
 	fc.IntVar(&info.ScrollPosition, _paneScrollPosition)
 	fc.BoolVar(&info.WindowZoomed, _windowZoomed)
+	fc.StringVar(&info.CurrentPath, _paneCurrentPath)
 
 	msg, parse := fc.Prepare()
 	out, err := driver.DisplayMessage(DisplayMessageRequest{

--- a/internal/tmux/inspect_test.go
+++ b/internal/tmux/inspect_test.go
@@ -13,7 +13,7 @@ import (
 func TestInspectPane(t *testing.T) {
 	t.Parallel()
 
-	message := []byte("%42\t@123\t80\t40\tcopy-mode\t40")
+	message := []byte("%42\t@123\t80\t40\tcopy-mode\t40\t0\t/home/user/dir")
 
 	ctrl := gomock.NewController(t)
 	mockTmux := tmuxtest.NewMockDriver(ctrl)
@@ -31,6 +31,7 @@ func TestInspectPane(t *testing.T) {
 		Height:         40,
 		Mode:           tmux.CopyMode,
 		ScrollPosition: 40,
+		CurrentPath:    "/home/user/dir",
 	}, got)
 
 	t.Run("String", func(t *testing.T) {
@@ -43,5 +44,6 @@ func TestInspectPane(t *testing.T) {
 		assert.Contains(t, s, "height: 40")
 		assert.Contains(t, s, "mode: copy-mode")
 		assert.Contains(t, s, "scrollPosition: 40")
+		assert.Contains(t, s, "currentPath: /home/user/dir")
 	})
 }

--- a/main.go
+++ b/main.go
@@ -187,6 +187,7 @@ func (cmd *mainCmd) Run(cfg *config) (err error) {
 			NewAction: (&actionFactory{
 				Log:     logger,
 				Environ: cmd.Environ,
+				Getwd:   os.Getwd,
 			}).New,
 		}
 	} else {


### PR DESCRIPTION
If the pane inside which tmux-fastcopy is invoked
makes the pane directory available via `pane_path`,
run the action inside that directory
instead of the process' current directory.

Includes a failing test case,
verifying that the directory that we run the fastcopy-action in
matches the directory of the pane when the action is invoked.

Resolves #148