### PR TITLE
Run actions with FASTCOPY_TARGET_PANE_ID set

### DIFF
--- a/.changes/unreleased/Added-20230618-145035.yaml
+++ b/.changes/unreleased/Added-20230618-145035.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: |
+  Actions are now run with `FASTCOPY_TARGET_PANE_ID` set to the ID of the pane
+  where fastcopy was invoked.
+  Use this to run operations against the pane from within the action.
+time: 2023-06-18T14:50:35.421519979-07:00

--- a/action_test.go
+++ b/action_test.go
@@ -78,6 +78,33 @@ func TestNewCommandAction(t *testing.T) {
 				Dir:        "/tmp",
 			},
 		},
+		{
+			desc: "stdin with pane ID",
+			give: newActionRequest{
+				Action:       "pbcopy",
+				TargetPaneID: "123",
+			},
+			wantStdin: &stdinAction{
+				Cmd:    "pbcopy",
+				Args:   []string{},
+				PaneID: "123",
+				Dir:    cwd,
+			},
+		},
+		{
+			desc: "argument with pane ID",
+			give: newActionRequest{
+				Action:       "tmux set-buffer -- {}",
+				TargetPaneID: "123",
+			},
+			wantArg: &argAction{
+				Cmd:        "tmux",
+				BeforeArgs: []string{"set-buffer", "--"},
+				AfterArgs:  []string{},
+				PaneID:     "123",
+				Dir:        cwd,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/app.go
+++ b/app.go
@@ -142,8 +142,9 @@ func (app *app) Run(cfg *config) error {
 	}
 
 	action, err := app.NewAction(newActionRequest{
-		Action: actionStr,
-		Dir:    targetPane.CurrentPath,
+		Action:       actionStr,
+		Dir:          targetPane.CurrentPath,
+		TargetPaneID: targetPane.ID,
 	})
 	if err != nil {
 		return fmt.Errorf("load action %q: %v", actionStr, err)

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,6 +13,7 @@
 - How to
     - [Access the regex name](howto-regex-name.md)
     - [Copy text to the clipboard](howto-clipboard.md)
+    - [Select text without copying](howto-select.md)
 - [FAQ](faq.md)
 - [Credits](credits.md)
 - [Similar projects](similar.md)

--- a/doc/howto-regex-name.md
+++ b/doc/howto-regex-name.md
@@ -1,4 +1,4 @@
-# Accessing the regex name
+# Access the regex name
 
 tmux-fastcopy executes the action with the `FASTCOPY_REGEX_NAME` environment
 variable set. This holds the [name of the regex](regex-names.md) that matched the

--- a/doc/howto-select.md
+++ b/doc/howto-select.md
@@ -1,0 +1,65 @@
+# Select text without copying
+
+If you'd like to select the matched text rather than copy in,
+you can define an action that takes the target pane in copy mode,
+and moves your cursor over to the matched text.
+
+The following script should suffice for this:
+
+```bash
+#!/usr/bin/env bash
+
+MATCH_TEXT="$1"
+PANE_ID="$FASTCOPY_TARGET_PANE_ID"
+
+tmux \
+	copy-mode -t "$PANE_ID" ';' \
+	send-keys -t "$PANE_ID" -X search-backward-text "$MATCH_TEXT" ';' \
+	send-keys -t "$PANE_ID" -X begin-selection ';' \
+	send-keys -t "$PANE_ID" -X -N "$((${#MATCH_TEXT} - 1))" cursor-right ';' \
+	send-keys -t "$PANE_ID" -X end-selection
+```
+
+<details>
+<summary>Explanation</summary>
+
+The script above expects the matched text as an argument,
+and grabs the target pane ID from the environment.
+tmux-fastcopy sets `FASTCOPY_TARGET_PANE_ID` when running the action
+(see [Execution context](opt-action.md#execution-context)).
+
+It then runs the following tmux commands on the pane:
+
+- switch it to copy mode
+- search for the closest recent instance of the matched text
+  and move your cursor there
+- begin a selection
+- move the cursor to the end of the selected text
+- end the selection
+
+The end result of this is that when the action runs,
+your cursor will have selected the matched text
+leaving you room to adjust the selection before copying.
+
+</details>
+
+Place this script in a location of your choice, say, `~/.tmux/select.sh`
+and mark it as an executable:
+
+```bash
+chmod +x ~/.tmux/select.sh
+```
+
+Then add the following to your `~/tmux.conf`.
+
+```tmux
+set -g @fastcopy-action '~/.tmux/select.sh {}'
+```
+
+Or add the following if you want to do this
+only when you press shift along with the label
+(see [`@fastcopy-shift-action`](opt-shift-action.md)).
+
+```tmux
+set -g @fastcopy-shift-action '~/.tmux/select.sh {}'
+```

--- a/doc/opt-action.md
+++ b/doc/opt-action.md
@@ -28,3 +28,13 @@ It is not executed in the context of a full login shell.
 
 The command runs inside the directory of the pane
 where tmux-fastcopy was invoked if this information is available from tmux.
+It runs with the following environment variables set:
+
+- `FASTCOPY_REGEX_NAME`:
+  Name of `@fastcopy-regex` rule that matched.
+  See [Regex names](regex-names.md) and [Accessing the regex name](howto-regex-name.md)
+  for more information.
+- `FASTCOPY_TARGET_PANE_ID`:
+  Unique identifier for the pane inside which fastcopy was invoked.
+  Use this when running tmux operations inside the action
+  to target them to that pane.

--- a/doc/opt-shift-action.md
+++ b/doc/opt-shift-action.md
@@ -13,7 +13,6 @@ selected text.
 
     set-option -g @fastcopy-shift-action "fastcopy-shift.sh {}"
 
-As with `@fastcopy-action`, tmux-fastcopy will set `FASTCOPY_REGEX_NAME` to the
-name of the regular expression that matched when running the
-`@fastcopy-shift-action`.
-See [Accessing the regex name](howto-regex-name.md) for more details.
+The `@fastcopy-shift-action` will run with the same
+[execution context](opt-action.md#execution-context)
+as the `@fastcopy-action`.


### PR DESCRIPTION
Sets FASTCOPY_TARGET_PANE_ID when running actions
to the ID of the pane where tmux-fastcopy was invoked.
This may be used with `tmux` operations (usually with the `-t` flag)
to run operations against that pane from within the action.

Resolves #155
