### PR TITLE
release: Drop Windows

### DIFF
--- a/.changes/unreleased/Removed-20230914-210444.yaml
+++ b/.changes/unreleased/Removed-20230914-210444.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: Drop Windows builds.
+time: 2023-09-14T21:04:44.559388193-07:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,12 +16,9 @@ builds:
       - arm64
     goos:
       - linux
-      - windows
       - darwin
     goarm: [5, 6, 7]
     ignore:
-      - goos: windows
-        goarch: arm
       - goos: darwin
         goarch: arm
     ldflags: '-s -w -X main._version={{.Version}}'


### PR DESCRIPTION
We've been publishing Windows binaries but
I don't think this has ever worked.
It slows down releases for no reason.
