### PR TITLE
fix: Don't hang when destroy-unattached is set

### DIFF
--- a/.changes/unreleased/Fixed-20231015-123720.yaml
+++ b/.changes/unreleased/Fixed-20231015-123720.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix hang when destroy-unattached is set to on.
+time: 2023-10-15T12:37:20.215283612-07:00

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -33,9 +33,24 @@ type Driver interface {
 	// for this signal.
 	SendSignal(string) error
 
-	// ShowOptions runs the tmux shopw-options command and returns its
+	// ShowOptions runs the tmux show-options command and returns its
 	// output.
 	ShowOptions(ShowOptionsRequest) ([]byte, error)
+
+	// SetOption runs the tmux set-option command.
+	SetOption(SetOptionRequest) error
+}
+
+// SetOptionRequest specifies the parameters for the set-option command.
+type SetOptionRequest struct {
+	// Name of the option to set.
+	Name string
+
+	// Value to set the option to.
+	Value string
+
+	// Whether this option should be changed globally.
+	Global bool
 }
 
 // NewSessionRequest specifies the parameter for a new-session command.

--- a/internal/tmux/shell.go
+++ b/internal/tmux/shell.go
@@ -151,6 +151,23 @@ func (s *ShellDriver) CapturePane(req CapturePaneRequest) ([]byte, error) {
 	return s.run.Output(cmd)
 }
 
+// SetOption runs the set-option command with the given parameters.
+func (s *ShellDriver) SetOption(req SetOptionRequest) error {
+	s.init()
+
+	args := []string{"set-option"}
+	if req.Global {
+		args = append(args, "-g")
+	}
+	args = append(args, req.Name, req.Value)
+
+	cmd := s.cmd(args...)
+	defer s.errorWriter(&cmd.Stderr)()
+
+	s.log.Debugf("set-option: %v", req)
+	return s.run.Run(cmd)
+}
+
 // DisplayMessage displays the given message in tmux and returns its output.
 func (s *ShellDriver) DisplayMessage(req DisplayMessageRequest) ([]byte, error) {
 	s.init()

--- a/internal/tmux/shell_test.go
+++ b/internal/tmux/shell_test.go
@@ -180,6 +180,44 @@ func TestDisplayMessageArgs(t *testing.T) {
 	}
 }
 
+func TestSetOptionArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give SetOptionRequest
+		want []string
+	}{
+		{
+			desc: "local",
+			give: SetOptionRequest{Name: "foo", Value: "bar"},
+			want: []string{"set-option", "foo", "bar"},
+		},
+		{
+			desc: "global",
+			give: SetOptionRequest{Name: "foo", Value: "bar", Global: true},
+			want: []string{"set-option", "-g", "foo", "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			r := newFakeRunner(t)
+			r.ExpectOutput("tmux", tt.want...)
+
+			driver := ShellDriver{
+				run: r.Runner(),
+				log: logtest.NewLogger(t),
+			}
+			err := driver.SetOption(tt.give)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestSwapPaneArgs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmux/tmuxopt/tmuxopt.go
+++ b/internal/tmux/tmuxopt/tmuxopt.go
@@ -144,6 +144,27 @@ func (v *stringValue) Set(s string) error {
 	return nil
 }
 
+type boolValue bool
+
+// BoolVar specifies that the given option should be loaded as a boolean.
+func (l *Loader) BoolVar(dest *bool, option string) {
+	l.init()
+
+	l.Var((*boolValue)(dest), option)
+}
+
+func (v *boolValue) Set(s string) error {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "on", "yes", "true", "1":
+		*(*bool)(v) = true
+	case "off", "no", "false", "0":
+		*(*bool)(v) = false
+	default:
+		return fmt.Errorf("invalid boolean value %q", s)
+	}
+	return nil
+}
+
 func readValue(v []byte) (value string) {
 	if len(v) == 0 {
 		return ""

--- a/internal/tmux/tmuxtest/mock_driver.go
+++ b/internal/tmux/tmuxtest/mock_driver.go
@@ -121,6 +121,20 @@ func (mr *MockDriverMockRecorder) SendSignal(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSignal", reflect.TypeOf((*MockDriver)(nil).SendSignal), arg0)
 }
 
+// SetOption mocks base method.
+func (m *MockDriver) SetOption(arg0 tmux.SetOptionRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetOption", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetOption indicates an expected call of SetOption.
+func (mr *MockDriverMockRecorder) SetOption(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOption", reflect.TypeOf((*MockDriver)(nil).SetOption), arg0)
+}
+
 // ShowOptions mocks base method.
 func (m *MockDriver) ShowOptions(arg0 tmux.ShowOptionsRequest) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
tmux supports a session option 'destroy-unattached' which, when set,
terminates unattached sessions very quickly.

This is a problem for tmux-fastcopy
because it places its temporary window in an unattached session
so as not to have a flicker at the bottom of the user's current session.

Unfortunately, there doesn't appear to be an obvious/easy way
to spawn a session with the option unset *just for it*.
As a workaround, if the user has destroy-unattached set,
the wrapper program will temporarily disable it,
and re-enable it after tmux-fastcopy exits.

Resolves #160
