### PR TITLE
goreleaser: brews.tap => brews.repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ aurs:
       email: mail@abhinavg.net
 
 brews:
-  - tap:
+  - repository:
       owner: abhinav
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Per https://goreleaser.com/deprecations/#brewstap,
the brews.tap option has been replaced with brews.repository.
