### PR TITLE
huffman: optimize label assignment slightly

### DIFF
--- a/.changes/unreleased/Fixed-20241127-171732.yaml
+++ b/.changes/unreleased/Fixed-20241127-171732.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Tweak label assignment algorithm to generate shorter labels in certain cases.
+time: 2024-11-27T17:17:32.425602-08:00

--- a/internal/huffman/huffman.go
+++ b/internal/huffman/huffman.go
@@ -1,29 +1,44 @@
-// Package huffman implements an n-ary Huffman coding algorithm
-// to generate prefix-free labels for a set of items.
+// Package huffman implements an n-ary Huffman coding algorithm.
+//
+// It can be used to generate prefix-free labels for any number of items.
+// Prefix-free labels are labels where for any two labels X and Y,
+// there's a guarantee that X is not a prefix of Y.
+// This is a useful property because it allows for unambiguous matching.
+// When receiving incremental input (e.g. keystrokes),
+// as soon as the input matches a prefix-free label X,
+// you can stop and process the item corresponding to X.
 package huffman
 
-import "container/heap"
+import (
+	"container/heap"
+)
 
-// Label generates unique prefix-free labels for a set of items given their
-// frequencies. Prefix-free labels guarantee that none of the generated labels
-// is a prefix for another.
+// Label generates unique prefix-free labels for items given their frequencies.
 //
-// For each item i, freqs[i] specifies its frequency. Items with higher
-// frequencies will get shorter labels.
+// base is the number of symbols in the alphabet.
+// For example, for a binary alphabet, base should be 2.
+// base=26 is a common choice for alphabetic labels.
+// The mapping from base to alphabet is the caller's responsibility.
+// base must be at least 2.
 //
-// Labels are generated using an alphabet of the provided size. For each item
-// i, labels[i] is a list of indexes in the alphabet that comprise that item's
-// label. For example, given a binary alphabet {a b}, the label {0 1 0} means
-// "aba".
-func Label(alphabetSize int, freqs []int) (labels [][]int) {
-	// This implements Huffman coding using a priority queue using the
-	// method outlined on Wikipedia [1], altering it for n-ary trees also
-	// using advice from the same page. In the interest of keeping the
-	// solution simple, we don't generate low-frequency placeholder nodes.
+// For len(freqs) items, freqs[i] specifies the frequency of item i.
+// Items with higher frequencies will be assigned shorter labels.
+//
+// The returned value is a list of labels for each item.
+// labels[i] is the label for item i,
+// specified as indexes into the alphabet.
+// For example, given a binary alphabet {a b},
+// the label {0 1 0} means "aba".
+func Label(base int, freqs []int) (labels [][]int) {
+	// This implements Huffman coding with a priority queue
+	// using the method outlined on Wikipedia [1],
+	// altering it for n-ary trees also using advice from the same page.
+	// Further advice on optizing comes from rdbliss/huffman [2].
 	//
 	// [1]: https://en.wikipedia.org/wiki/Huffman_coding#Basic_technique
+	// [2]: https://github.com/rdbliss/huffman/
 
-	if alphabetSize < 2 {
+	if base < 2 {
 		panic("alphabet must have at least two elements")
 	}
 
@@ -31,8 +46,8 @@ func Label(alphabetSize int, freqs []int) (labels [][]int) {
 	case 0:
 		return nil
 	case 1:
-		// special-case: If there's only one item, create a single
-		// letter alabel.
+		// special-case:
+		// If there's only one item, create a single letter label.
 		return [][]int{{0}}
 	}
 
@@ -43,12 +58,20 @@ func Label(alphabetSize int, freqs []int) (labels [][]int) {
 	}
 	heap.Init(&nodeHeap)
 
-	for len(nodeHeap) > 1 {
-		var (
-			children []*node
-			freq     int
-		)
-		for i := 0; i < alphabetSize && len(nodeHeap) > 0; i++ {
+	// This is the meat of the logic.
+	//
+	//  - Assign letters [0, $base) to the least frequent items
+	//    and remove them from the heap.
+	//  - Create a new node that represents these $base items
+	//    and push it back into the heap.
+	//  - Repeat until there's only one node left in the heap.
+	//
+	// We'll end up with a tree where each node has up to $base children.
+	// The path from root down to leaf nodes will is the label for that item.
+	combine := func(numChildren int) {
+		children := make([]*node, 0, numChildren)
+		var freq int
+		for i := 0; i < numChildren && len(nodeHeap) > 0; i++ {
 			child := heap.Pop(&nodeHeap).(*node)
 			children = append(children, child)
 			freq += child.Freq
@@ -61,14 +84,30 @@ func Label(alphabetSize int, freqs []int) (labels [][]int) {
 		})
 	}
 
+	// Special-case: for the first iteration,
+	// assign fewer letters to the least frequent items.
+	// This will ensure high frequency nodes don't unnecessarily
+	// get longer labels because a couple extra nodes pushed them
+	// over the edge of $base, requiring a new branch above.
+	//
+	// See https://github.com/rdbliss/huffman/blob/master/notes.md#generalization
+	initial := 2 + (len(nodeHeap)-2)%(base-1)
+	if initial > 0 {
+		combine(initial)
+	}
+
+	for len(nodeHeap) > 1 {
+		combine(base)
+	}
+
 	// nodeHeap now contains a single element. We'll use it now as a stack
 	// to iterate through the node tree.
 	labels = make([][]int, len(freqs))
 
 	var labelNode func(*node, []int)
 	labelNode = func(n *node, prefix []int) {
-		// If we found a leaf, copy the label (iterating into sibilings
-		// will mutate it).
+		// If we found a leaf, copy the label
+		// (iterating into sibilings will mutate it).
 		if i := n.Index; i >= 0 {
 			label := make([]int, len(prefix))
 			copy(label, prefix)
@@ -92,7 +131,7 @@ type node struct {
 	// branch nodes.
 	Index int
 
-	// Up to alphabetSize children of the node. This is nil for leaf nodes.
+	// Up to base children of the node. This is nil for leaf nodes.
 	Children []*node
 
 	// Frequency of the leaf node, or the combined frequency of the leaf

--- a/internal/huffman/huffman_test.go
+++ b/internal/huffman/huffman_test.go
@@ -95,11 +95,33 @@ func TestLabel(t *testing.T) {
 		{
 			alphabet: _abcd,
 			items: []item{
-				{5, "a"},
-				{4, "bd"},
-				{3, "bc"},
+				{10, "dc"},
+				{12, "dd"},
+				{7, "dbb"},
+				{8, "da"},
+				{32, "c"},
+				{1, "dba"},
+				{17, "a"},
+				{18, "b"},
+			},
+		},
+		{
+			alphabet: _abcd,
+			items: []item{
+				{5, "d"},
+				{4, "c"},
+				{3, "a"},
 				{2, "bb"},
 				{1, "ba"},
+			},
+		},
+		{
+			alphabet: _abcd,
+			items: []item{
+				{50, "d"},
+				{25, "c"},
+				{12, "b"},
+				{6, "a"},
 			},
 		},
 	}


### PR DESCRIPTION
The huffman algorithm works by building a tree
where each node has up to $base children (for a $base alphabet).
High frequency nodes are near the root of the tree,
and low frequency nodes are near the bottom.
Path from root to leaf nodes is the label for that item.

Previously, when building the tree,
we would cluster the items with the lowest frequency
into a node of size $base.
This would result in cases where the topmost nodes (highest frequency)
have fewer than $base children.

So when we assign labels, a few items end up in a lower level
than they could given their frequency and room in the topmost nodes.
So e.g. if there are 4 nodes (A-D), and base is 3. we create the tree:

         *
        /|
      0/ |1
      D  *
        /|\
      0/ |1\2
      A  B  C

This results in the labels:

    D: 0
    A: 10
    B: 11
    C: 12

This PR changes the algorithm slightly so that topmost node
always has $base children,
and the first cluster we create (the lowest frequency nodes)
gets < $base children if that's the case we're in.

As a result, we'll build the tree:

          *
         /|\
       0/ |1\2
        D A  *
            /|
          0/ |1
          B  C

This results in the labels:

    D: 0
    A: 1
    B: 20
    C: 21

More nodes get single-letter labels than before.